### PR TITLE
fix: 修复交火向量索引删楼后召回失效的问题

### DIFF
--- a/src/data/storage/vector-index-st-files-storage.ts
+++ b/src/data/storage/vector-index-st-files-storage.ts
@@ -191,6 +191,19 @@ export async function sha256Text_ACU(text: string): Promise<string> {
     return `fallback-${Math.abs(hash)}`;
 }
 
+// 会话级"已确认缺失(404)"外置文件路径集合：
+// 读分片遇 404 时记录，后续同会话对该路径直接短路（不再联网重试）；
+// 上传成功后移除，供写入侧(rolling delta 折叠判定)检测 base 死指针并强制重写。
+const confirmedMissingVectorFilePaths_ACU = new Set<string>();
+
+export function isVectorIndexFilePathConfirmedMissing_ACU(path: string): boolean {
+    return !!path && confirmedMissingVectorFilePaths_ACU.has(path);
+}
+
+export function markVectorIndexFilePathConfirmedMissing_ACU(path: string): void {
+    if (path) confirmedMissingVectorFilePaths_ACU.add(path);
+}
+
 export async function uploadVectorIndexJsonFile_ACU(params: {
     path: string;
     role: SummaryVectorIndexExternalFileRole_ACU;
@@ -217,6 +230,7 @@ export async function uploadVectorIndexJsonFile_ACU(params: {
             return { ok: false, error: `上传失败 ${response.status}: ${detail}` };
         }
         const now = new Date().toISOString();
+        confirmedMissingVectorFilePaths_ACU.delete(params.path);
         return {
             ok: true,
             ref: {

--- a/src/service/vector/summary-vector-index-archive-service.ts
+++ b/src/service/vector/summary-vector-index-archive-service.ts
@@ -36,6 +36,7 @@ import {
     normalizeSummaryVectorIndexManifestForRead_ACU,
     persistSummaryVectorIndexSnapshot_ACU,
 } from './summary-vector-index-storage-service';
+import { isMissingExternalVectorFileError_ACU } from './summary-vector-index-cache-service';
 import { hashUserInput_ACU, isSummaryOrOutlineTable_ACU, logDebug_ACU, logWarn_ACU } from '../../shared/utils';
 
 type SummaryVectorIndexArchiveMode_ACU = 'append' | 'sync';
@@ -620,17 +621,35 @@ async function hydrateAggregatedSummaryVectorIndexSnapshot_ACU(
     const mergedChunks = new Map<string, ChatSummaryVectorIndexChunk_ACU>();
     let latestState: ChatSummaryVectorIndexState_ACU | null = null;
 
-    for (const layer of snapshot.layers) {
+    // 只有"最新有效层"和"内容寻址层"才联网加载外置分片：
+    // rolling delta 折叠后旧层 base 指针必然悬空(其 chunks 已被最新层覆盖)，
+    // 逐层联网只会产生 O(楼层数) 次无害 404 刷屏并拖慢归档/召回。
+    const latestLayerIndex = snapshot.layers.length - 1;
+    const HISTORICAL_LAYER_MISSING_ERROR_LIMIT = 8;
+    let historicalMissingErrorCount = 0;
+
+    for (let layerIndex = 0; layerIndex < snapshot.layers.length; layerIndex += 1) {
+        const layer = snapshot.layers[layerIndex];
         const state = cloneSummaryVectorIndexState_ACU(layer.summaryVectorIndexState);
         if (!state) continue;
         if (state.manifest && (!Array.isArray(state.chunks) || state.chunks.length === 0)) {
-            try {
-                const externalChunks = await loadSummaryVectorIndexChunksFromManifest_ACU(state.manifest);
-                if (externalChunks.length > 0) {
-                    state.chunks = externalChunks;
+            const isLatestLayer = layerIndex === latestLayerIndex;
+            const isContentAddressedLayer = (state.manifest.contentAddressed?.chunkRefs?.length || 0) > 0;
+            const shouldLoadExternal = isLatestLayer
+                || (isContentAddressedLayer && historicalMissingErrorCount < HISTORICAL_LAYER_MISSING_ERROR_LIMIT);
+            if (shouldLoadExternal) {
+                try {
+                    const externalChunks = await loadSummaryVectorIndexChunksFromManifest_ACU(state.manifest);
+                    if (externalChunks.length > 0) {
+                        state.chunks = externalChunks;
+                    }
+                } catch (error) {
+                    if (!isLatestLayer) {
+                        const message = error instanceof Error ? error.message : String(error || '');
+                        if (isMissingExternalVectorFileError_ACU(message)) historicalMissingErrorCount += 1;
+                    }
+                    logWarn_ACU('[纪要向量索引] 加载历史外置分片失败，保留该层 manifest，禁止因缺失 chunks 清理旧层:', error);
                 }
-            } catch (error) {
-                logWarn_ACU('[纪要向量索引] 加载历史外置分片失败，保留该层 manifest，禁止因缺失 chunks 清理旧层:', error);
             }
         }
         hydratedLayers.push({ ...layer, summaryVectorIndexState: state });

--- a/src/service/vector/summary-vector-index-storage-service.ts
+++ b/src/service/vector/summary-vector-index-storage-service.ts
@@ -9,7 +9,9 @@ import {
     buildVectorIndexStableFilePath_ACU,
     deleteRegisteredVectorIndexFilesWhere_ACU,
     deleteVectorIndexFile_ACU,
+    isVectorIndexFilePathConfirmedMissing_ACU,
     loadVectorIndexRegistry_ACU,
+    markVectorIndexFilePathConfirmedMissing_ACU,
     readVectorIndexJsonFile_ACU,
     registerVectorIndexFiles_ACU,
     sha256Text_ACU,
@@ -974,7 +976,17 @@ async function persistSummaryVectorIndexSnapshotAsRollingDelta_ACU(params: {
         });
         const reusableBaseChunkIds = new Set(reusableBaseBatch?.chunkIds || []);
         const foldThreshold = Math.max(1, Math.floor(Number(params.foldThreshold) || 1));
-        const shouldFold = !reusableBaseBatch || reusableBaseChunkIds.size === 0 || changedRowKeys.size >= foldThreshold;
+        // 复用的 base 分片若已被确认缺失(404，如删楼退回折叠点之前的悬空层)，
+        // 必须无条件强制折叠重写 base，否则死指针只写 delta 永远补不回（base 404 死锁）。
+        const reusableBaseShardPaths = (reusableBaseBatch?.files || [])
+            .filter((file) => file?.role === 'base_shard' && !!file?.path)
+            .map((file) => file.path);
+        const baseFileConfirmedMissing = reusableBaseShardPaths.length > 0
+            && reusableBaseShardPaths.some((path) => isVectorIndexFilePathConfirmedMissing_ACU(path));
+        const shouldFold = !reusableBaseBatch
+            || reusableBaseChunkIds.size === 0
+            || changedRowKeys.size >= foldThreshold
+            || baseFileConfirmedMissing;
         const activeRowKeySet = new Set(activeRowKeys);
         const changedActiveRowKeys = new Set(Array.from(changedRowKeys).filter((rowKey) => activeRowKeySet.has(rowKey)));
         const baseChunks = shouldFold ? chunks : [];
@@ -1022,7 +1034,16 @@ async function persistSummaryVectorIndexSnapshotAsRollingDelta_ACU(params: {
             return written.ref;
         };
 
-        const baseShardRef = shouldFold ? await writeShard('base', 'base_0001', baseChunks) : null;
+        // 折叠时 base 按块数上限拆多分片写入，规避单大文件上传被 413/500 截断导致 base 从未落盘
+        const baseShardRefs: SummaryVectorIndexExternalFileRef_ACU[] = [];
+        if (shouldFold) {
+            const baseShardGroups = chunkArray_ACU(baseChunks, DEFAULT_SHARD_CHUNK_LIMIT_ACU);
+            for (let shardIndex = 0; shardIndex < baseShardGroups.length; shardIndex += 1) {
+                const shardId = `base_${String(shardIndex + 1).padStart(4, '0')}`;
+                const written = await writeShard('base', shardId, baseShardGroups[shardIndex]);
+                if (written) baseShardRefs.push(written);
+            }
+        }
         const deltaShardRef = await writeShard('delta', 'delta_0001', deltaChunks);
         const baseBatch: SummaryVectorIndexBatchRef_ACU = shouldFold
             ? {
@@ -1033,7 +1054,7 @@ async function persistSummaryVectorIndexSnapshotAsRollingDelta_ACU(params: {
                     updatedAt: indexedAt,
                     rows: baseRows,
                     chunks: baseChunks,
-                    files: baseShardRef ? [baseShardRef] : [],
+                    files: baseShardRefs,
                     sourceMessageIndex: options.sourceMessageIndex,
                     sourceSnapshotMessageId: options.snapshotMessageId,
                 }),
@@ -1162,7 +1183,7 @@ async function persistSummaryVectorIndexSnapshotAsRollingDelta_ACU(params: {
         } catch (error) {
             logWarn_ACU('[纪要向量索引] rolling delta 旧分片清理失败，保留当前快照继续运行:', error);
         }
-        logDebug_ACU(`[交火向量索引] 已写入 rolling delta 快照：fold=${shouldFold ? 'yes' : 'no'} changedRows=${changedRowKeys.size}`);
+        logDebug_ACU(`[交火向量索引] 已写入 rolling delta 快照：fold=${shouldFold ? 'yes' : 'no'} changedRows=${changedRowKeys.size}${baseFileConfirmedMissing ? ' forcedByMissingBase=yes' : ''} baseShards=${shouldFold ? baseShardRefs.length : (reusableBaseBatch?.files?.length || 0)}`);
         return { state, manifest: finalManifest, uploadedFiles };
     } catch (error) {
         await rollbackUploadedFiles_ACU(uploadedFiles);
@@ -1485,8 +1506,16 @@ async function loadOneShardChunks_ACU(
         shard = await getVectorIndexCachedShard_ACU(indexId, ref.shardId, ref.checksum || '');
     }
     if (!shard) {
+        // 本会话已确认 404 的路径直接短路，避免旧层悬空指针反复联网重试刷屏
+        if (ref.path && isVectorIndexFilePathConfirmedMissing_ACU(ref.path)) {
+            throw new Error(`交火向量索引分片读取失败: ${ref.path} 文件已确认缺失(404)，本会话跳过网络重试`);
+        }
         const loaded = await readVectorIndexJsonFile_ACU<SummaryVectorIndexShard_ACU>(ref.path);
         if (!loaded.ok || !loaded.data) {
+            // 记录已确认缺失(404)的分片路径，供 rolling delta 折叠判定强制重写 base
+            if (loaded.status === 404 && ref.path) {
+                markVectorIndexFilePathConfirmedMissing_ACU(ref.path);
+            }
             throw new Error(`交火向量索引分片读取失败: ${ref.path} ${loaded.error || ''}`.trim());
         }
         const loadedShard = loaded.data;

--- a/tests/data/storage/vector-index-st-files-storage.test.ts
+++ b/tests/data/storage/vector-index-st-files-storage.test.ts
@@ -1,0 +1,96 @@
+/**
+ * tests/data/storage/vector-index-st-files-storage.test.ts
+ * 真实模块测试：会话级"已确认缺失(404)"路径集合与读/写行为
+ *  - readVectorIndexJsonFile_ACU 对 HTTP 失败返回 status（404 判定依据）
+ *  - mark/is 缺失集合语义
+ *  - uploadVectorIndexJsonFile_ACU 成功后将路径从缺失集合移除
+ * @vitest-environment jsdom
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../../src/shared/host-api', () => ({
+  SillyTavern_API_ACU: {},
+}));
+
+import {
+  isVectorIndexFilePathConfirmedMissing_ACU,
+  markVectorIndexFilePathConfirmedMissing_ACU,
+  readVectorIndexJsonFile_ACU,
+  uploadVectorIndexJsonFile_ACU,
+} from '../../../src/data/storage/vector-index-st-files-storage';
+
+const mockFetch = vi.fn();
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', mockFetch);
+  mockFetch.mockReset();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('readVectorIndexJsonFile_ACU', () => {
+  it('HTTP 404 时返回 ok=false 且 status=404', async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 404, statusText: 'Not Found' });
+    const result = await readVectorIndexJsonFile_ACU('vec/missing.json');
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(404);
+    expect(result.error).toContain('404');
+  });
+
+  it('网络异常（无响应）时返回 ok=false 且无 status', async () => {
+    mockFetch.mockRejectedValue(new Error('network down'));
+    const result = await readVectorIndexJsonFile_ACU('vec/unreachable.json');
+    expect(result.ok).toBe(false);
+    expect(result.status).toBeUndefined();
+  });
+});
+
+describe('已确认缺失(404)路径集合', () => {
+  it('mark 后 is 返回 true，未 mark 的路径返回 false；空路径不记录', () => {
+    const path = `vec/case-mark-${Date.now()}.json`;
+    expect(isVectorIndexFilePathConfirmedMissing_ACU(path)).toBe(false);
+    markVectorIndexFilePathConfirmedMissing_ACU(path);
+    expect(isVectorIndexFilePathConfirmedMissing_ACU(path)).toBe(true);
+    expect(isVectorIndexFilePathConfirmedMissing_ACU('vec/other.json')).toBe(false);
+    markVectorIndexFilePathConfirmedMissing_ACU('');
+    expect(isVectorIndexFilePathConfirmedMissing_ACU('')).toBe(false);
+  });
+
+  it('上传成功后路径从缺失集合移除', async () => {
+    const path = `vec/case-upload-${Date.now()}.json`;
+    markVectorIndexFilePathConfirmedMissing_ACU(path);
+    expect(isVectorIndexFilePathConfirmedMissing_ACU(path)).toBe(true);
+
+    mockFetch.mockResolvedValue({ ok: true });
+    const result = await uploadVectorIndexJsonFile_ACU({
+      path,
+      role: 'base_shard',
+      shardId: 'base_0001',
+      data: { hello: 'world' },
+      chunkCount: 1,
+      status: 'ready',
+    });
+    expect(result.ok).toBe(true);
+    expect(result.ref?.path).toBe(path);
+    expect(isVectorIndexFilePathConfirmedMissing_ACU(path)).toBe(false);
+  });
+
+  it('上传失败时路径仍保留在缺失集合中', async () => {
+    const path = `vec/case-upload-fail-${Date.now()}.json`;
+    markVectorIndexFilePathConfirmedMissing_ACU(path);
+
+    mockFetch.mockResolvedValue({ ok: false, status: 500, statusText: 'Internal Server Error', text: async () => 'boom' });
+    const result = await uploadVectorIndexJsonFile_ACU({
+      path,
+      role: 'base_shard',
+      shardId: 'base_0001',
+      data: { hello: 'world' },
+      chunkCount: 1,
+      status: 'ready',
+    });
+    expect(result.ok).toBe(false);
+    expect(isVectorIndexFilePathConfirmedMissing_ACU(path)).toBe(true);
+  });
+});

--- a/tests/service/vector/summary-vector-index-hydrate-gating.test.ts
+++ b/tests/service/vector/summary-vector-index-hydrate-gating.test.ts
@@ -1,0 +1,197 @@
+/**
+ * tests/service/vector/summary-vector-index-hydrate-gating.test.ts
+ * 改动点 3 回归测试：hydrate 聚合快照时，只有"最新层"和"内容寻址旧层"联网加载外置分片，
+ * rolling 旧层（悬空 base 指针来源）不再逐层联网，消除 O(楼层数) 404 刷屏。
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  mockChat,
+  mockCurrentJsonTableDataRef,
+  mockCreateEmbeddings,
+  mockPersistSummaryVectorIndexSnapshot,
+  mockLoadChunksFromManifest,
+  mockReadIsolatedTagData,
+  mockWriteIsolatedTagData,
+  mockSaveChatToHost,
+} = vi.hoisted(() => {
+  const mockChat = [] as any[];
+  const mockCurrentJsonTableDataRef = { value: {} as any };
+  return {
+    mockChat,
+    mockCurrentJsonTableDataRef,
+    mockCreateEmbeddings: vi.fn(),
+    mockPersistSummaryVectorIndexSnapshot: vi.fn(),
+    mockLoadChunksFromManifest: vi.fn(async () => [] as any[]),
+    mockReadIsolatedTagData: vi.fn((message: any, isolationKey: string) => message?.TavernDB_ACU_IsolatedData?.[isolationKey || ''] || null),
+    mockWriteIsolatedTagData: vi.fn(),
+    mockSaveChatToHost: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+vi.mock('../../../src/service/runtime/state-manager', () => ({
+  get currentJsonTableData_ACU() { return mockCurrentJsonTableDataRef.value; },
+  currentChatFileIdentifier_ACU: 'test-chat',
+  getCurrentIsolationKey_ACU: vi.fn(() => ''),
+  settings_ACU: { dataIsolationEnabled: false, dataIsolationCode: '' },
+}));
+
+vi.mock('../../../src/service/chat/chat-service', () => ({
+  getChatArray_ACU: vi.fn(() => mockChat),
+}));
+
+vi.mock('../../../src/data/gateways/chat-gateway', () => ({
+  saveChatToHost_ACU: mockSaveChatToHost,
+}));
+
+vi.mock('../../../src/data/gateways/vector-embedding-gateway', () => ({
+  createEmbeddings_ACU: (...args: any[]) => mockCreateEmbeddings(...args),
+}));
+
+vi.mock('../../../src/service/vector/vector-memory-config', () => ({
+  getEffectiveSummaryVectorIndexConfig_ACU: vi.fn(() => ({
+    embeddingEndpoint: 'https://embedding.test',
+    embeddingApiKey: 'test-key',
+    embeddingModel: 'test-model',
+    summaryIndexChunkSentenceCount: 1,
+    summaryIndexArchiveMaxConcurrency: 10,
+    threshold: 1,
+    archiveTriggerCount: 1,
+    archiveBatchSize: 1,
+    archiveMaxConcurrency: 1,
+    topK: 1,
+    minScore: 0,
+    recallCandidateLimit: 1,
+    summaryPromptGroupId: 'summary',
+    entryComment: 'entry',
+    entryKey: 'key',
+  })),
+  validateSummaryVectorIndexConfig_ACU: vi.fn(() => ({ valid: true, errors: [] })),
+}));
+
+vi.mock('../../../src/service/vector/summary-vector-index-storage-service', () => ({
+  loadSummaryVectorIndexChunksFromManifest_ACU: mockLoadChunksFromManifest,
+  persistSummaryVectorIndexSnapshot_ACU: (...args: any[]) => mockPersistSummaryVectorIndexSnapshot(...args),
+  deleteSummaryVectorIndexExternal_ACU: vi.fn(),
+  isLegacySummaryVectorIndexManifest_ACU: vi.fn(() => false),
+  normalizeSummaryVectorIndexManifestForRead_ACU: vi.fn((manifest: any) => manifest),
+}));
+
+vi.mock('../../../src/data/repositories/chat-message-data-repo', () => ({
+  cloneIsolatedData_ACU: vi.fn((message: any) => JSON.parse(JSON.stringify(message?.TavernDB_ACU_IsolatedData || {}))),
+  readIsolatedTagData_ACU: mockReadIsolatedTagData,
+  writeIsolatedTagData_ACU: (...args: any[]) => mockWriteIsolatedTagData(...args),
+  writeMessageIdentity_ACU: vi.fn(),
+  writeLegacyCompatData_ACU: vi.fn(),
+}));
+
+import { archiveSummaryVectorIndexNow_ACU } from '../../../src/service/vector/summary-vector-index-archive-service';
+
+function buildLayerState(indexId: string, options: { contentAddressed?: boolean } = {}): any {
+  return {
+    summaryVectorIndexState: {
+      version: 1,
+      backend: 'st-files',
+      status: 'ready',
+      indexId,
+      snapshotMessageId: `msg-${indexId}`,
+      sourceTableKey: 'sheet_summary',
+      sourceTableName: '纪要表',
+      indexedAt: '2026-07-14T00:00:00.000Z',
+      rowCount: 1,
+      chunkCount: 1,
+      rows: [{
+        rowKey: `r-${indexId}`,
+        rowId: '1',
+        rowOrder: 0,
+        timeSpan: '上午',
+        location: '甲地',
+        summary: `事件 ${indexId}。`,
+        indexCode: 'AM-0001',
+        vectorSourceText: `事件 ${indexId}。`,
+        chunkIds: [`c-${indexId}`],
+      }],
+      manifest: {
+        version: 1,
+        backend: 'st-files',
+        status: 'ready',
+        indexId,
+        chatKey: 'test-chat',
+        isolationKey: '',
+        snapshotMessageId: `msg-${indexId}`,
+        sourceTableKey: 'sheet_summary',
+        sourceTableName: '纪要表',
+        indexedAt: '2026-07-14T00:00:00.000Z',
+        rowCount: 1,
+        chunkCount: 1,
+        snapshot: {
+          mode: 'base_rolling_delta',
+          revision: 1,
+          activeRowKeys: [`r-${indexId}`],
+          activeChunkIds: [`c-${indexId}`],
+        },
+        batchRefs: [{
+          role: 'base',
+          batchId: 'base_1',
+          indexId,
+          status: 'ready',
+          rowKeys: [`r-${indexId}`],
+          chunkIds: [`c-${indexId}`],
+          files: [{ role: 'base_shard', path: `vec/${indexId}_base_0001.json`, shardId: 'base_0001', status: 'ready' }],
+        }],
+        files: [],
+        ...(options.contentAddressed
+          ? { contentAddressed: { mode: 'content_addressed_chunks', chunkRefs: [{ path: `vec/${indexId}_chunk_1.json`, chunkKey: `key-${indexId}` }], activeChunkKeys: [`key-${indexId}`] } }
+          : {}),
+      },
+    },
+  };
+}
+
+function loadedManifestIndexIds(): string[] {
+  return mockLoadChunksFromManifest.mock.calls.map(([manifest]: any[]) => manifest?.indexId);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockChat.length = 0;
+  mockCurrentJsonTableDataRef.value = {
+    sheet_summary: {
+      name: '纪要表',
+      content: [
+        ['row_id', '时间跨度', '地点', '概要', '编码索引'],
+        ['1', '上午', '甲地', '第一次事件。', 'AM-0001'],
+      ],
+    },
+  };
+  mockCreateEmbeddings.mockImplementation(async (request: any) => request.input.map((_: string, index: number) => ({ index, embedding: [index + 1, index + 2] })));
+  mockLoadChunksFromManifest.mockImplementation(async () => []);
+});
+
+describe('hydrate 层级门控（改动点 3）', () => {
+  it('rolling 旧层不联网加载外置分片，最新层始终联网', async () => {
+    mockChat.push(
+      { is_user: false, mes: 'AI-1', id: 'm0', TavernDB_ACU_IsolatedData: { '': buildLayerState('idx-old') } },
+      { is_user: false, mes: 'AI-2', id: 'm1', TavernDB_ACU_IsolatedData: { '': buildLayerState('idx-new') } },
+    );
+
+    await archiveSummaryVectorIndexNow_ACU({ targetMessageIndex: 1, vectorizeOnly: true, force: true });
+
+    const loadedIds = loadedManifestIndexIds();
+    expect(loadedIds).toContain('idx-new');
+    expect(loadedIds).not.toContain('idx-old');
+  });
+
+  it('内容寻址旧层仍联网加载（不被跳过）', async () => {
+    mockChat.push(
+      { is_user: false, mes: 'AI-1', id: 'm0', TavernDB_ACU_IsolatedData: { '': buildLayerState('idx-old-ca', { contentAddressed: true }) } },
+      { is_user: false, mes: 'AI-2', id: 'm1', TavernDB_ACU_IsolatedData: { '': buildLayerState('idx-new') } },
+    );
+
+    await archiveSummaryVectorIndexNow_ACU({ targetMessageIndex: 1, vectorizeOnly: true, force: true });
+
+    const loadedIds = loadedManifestIndexIds();
+    expect(loadedIds).toContain('idx-new');
+    expect(loadedIds).toContain('idx-old-ca');
+  });
+});

--- a/tests/service/vector/summary-vector-index-storage-service.test.ts
+++ b/tests/service/vector/summary-vector-index-storage-service.test.ts
@@ -1,0 +1,285 @@
+/**
+ * tests/service/vector/summary-vector-index-storage-service.test.ts
+ * 交火向量索引 base 404 死锁修复单元测试：
+ *  - 改动点 2：读分片遇 404 记录路径并短路后续网络重试
+ *  - 改动点 1：复用 base 分片确认缺失时强制折叠（不受 15 条阈值限制）
+ *  - 改动点 4：折叠时 base 按块数上限拆多分片写入
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  missingPaths,
+  mockRead,
+  mockUpload,
+  mockGetCachedShard,
+} = vi.hoisted(() => {
+  const missingPaths = new Set<string>();
+  return {
+    missingPaths,
+    mockRead: vi.fn(),
+    mockUpload: vi.fn(async (params: any) => {
+      missingPaths.delete(params.path);
+      return {
+        ok: true,
+        ref: {
+          role: params.role,
+          path: params.path,
+          shardId: params.shardId,
+          byteSize: 16,
+          checksum: `ck-${params.path}`,
+          chunkCount: params.chunkCount,
+          rowCount: params.rowCount,
+          createdAt: '2026-07-14T00:00:00.000Z',
+          updatedAt: '2026-07-14T00:00:00.000Z',
+          status: params.status || 'ready',
+        },
+      };
+    }),
+    mockGetCachedShard: vi.fn(async () => null),
+  };
+});
+
+vi.mock('../../../src/data/storage/vector-index-st-files-storage', () => ({
+  buildVectorIndexFileName_ACU: vi.fn((p: any) => `vec/${p.indexId}_${p.role}${p.shardId ? `_${p.shardId}` : ''}.json`),
+  buildVectorIndexSingleSnapshotFilePath_ACU: vi.fn(() => 'vec/single_snapshot.json'),
+  buildVectorIndexSnapshotFilePath_ACU: vi.fn(() => 'vec/snapshot.json'),
+  buildVectorIndexStableDirectory_ACU: vi.fn(() => 'vec'),
+  buildVectorIndexStableFilePath_ACU: vi.fn(() => 'vec/stable.json'),
+  deleteRegisteredVectorIndexFilesWhere_ACU: vi.fn(async () => 0),
+  deleteVectorIndexFile_ACU: vi.fn(async (path: string) => ({ ok: true, path })),
+  isVectorIndexFilePathConfirmedMissing_ACU: (path: string) => missingPaths.has(path),
+  loadVectorIndexRegistry_ACU: vi.fn(async () => ({ version: 1, files: [] })),
+  markVectorIndexFilePathConfirmedMissing_ACU: (path: string) => { missingPaths.add(path); },
+  readVectorIndexJsonFile_ACU: (...args: any[]) => mockRead(...args),
+  registerVectorIndexFiles_ACU: vi.fn(async () => undefined),
+  sha256Text_ACU: vi.fn(async (text: string) => `sha-${String(text).length}`),
+  unregisterVectorIndexFiles_ACU: vi.fn(async () => undefined),
+  uploadVectorIndexJsonFile_ACU: mockUpload,
+}));
+
+vi.mock('../../../src/data/storage/vector-index-temp-cache', () => ({
+  deleteVectorIndexCacheByIndex_ACU: vi.fn(async () => undefined),
+  estimateVectorIndexTempCache_ACU: vi.fn(async () => ({ count: 0, bytes: 0 })),
+  getVectorIndexCachedShard_ACU: mockGetCachedShard,
+  putVectorIndexCachedShard_ACU: vi.fn(async () => undefined),
+}));
+
+vi.mock('../../../src/data/storage/vector-index-hot-cache', () => ({
+  deleteSummaryVectorHotCacheByIndex_ACU: vi.fn(async () => undefined),
+  estimateSummaryVectorFlushTasks_ACU: vi.fn(async () => 0),
+  estimateSummaryVectorHotCache_ACU: vi.fn(async () => ({ count: 0, bytes: 0 })),
+  getSummaryVectorHotCacheChunks_ACU: vi.fn(async () => null),
+  putSummaryVectorHotCacheChunks_ACU: vi.fn(async () => undefined),
+}));
+
+vi.mock('../../../src/service/runtime/state-manager', () => ({
+  getCurrentIsolationKey_ACU: vi.fn(() => 'default'),
+  currentChatFileIdentifier_ACU: 'test-chat',
+}));
+
+vi.mock('../../../src/shared/template-preset-utils', () => ({
+  getCurrentCharacterCardName_ACU: vi.fn(() => 'TestChar'),
+}));
+
+vi.mock('../../../src/service/vector/summary-vector-index-state-service', () => ({
+  getAggregatedSummaryVectorIndexSnapshot_ACU: vi.fn(() => null),
+}));
+
+vi.mock('../../../src/service/vector/vector-memory-config', () => ({
+  getEffectiveSummaryVectorIndexConfig_ACU: vi.fn(() => ({
+    summaryIndexRollingDeltaEnabled: true,
+    summaryIndexRollingDeltaFoldThreshold: 15,
+  })),
+}));
+
+import {
+  loadSummaryVectorIndexChunksFromManifest_ACU,
+  persistSummaryVectorIndexSnapshot_ACU,
+} from '../../../src/service/vector/summary-vector-index-storage-service';
+
+const BASE_SHARD_PATH = 'vec/idx-prev_base_shard_base_0001.json';
+
+function buildRollingManifest(): any {
+  return {
+    version: 1,
+    backend: 'st-files',
+    status: 'ready',
+    indexId: 'idx-prev',
+    chatKey: 'test-chat',
+    isolationKey: 'default',
+    snapshotMessageId: 'msg-1',
+    sourceTableKey: 'sheet_summary',
+    sourceTableName: '纪要表',
+    indexedAt: '2026-07-14T00:00:00.000Z',
+    rowCount: 1,
+    chunkCount: 1,
+    snapshot: {
+      mode: 'base_rolling_delta',
+      revision: 2,
+      activeRowKeys: ['r1'],
+      activeChunkIds: ['c1'],
+      removedRowKeys: [],
+      replacedRowKeys: [],
+    },
+    batchRefs: [
+      {
+        role: 'base',
+        batchId: 'base_2',
+        indexId: 'idx-prev',
+        status: 'ready',
+        rowKeys: ['r1'],
+        chunkIds: ['c1'],
+        files: [
+          {
+            role: 'base_shard',
+            path: BASE_SHARD_PATH,
+            shardId: 'base_0001',
+            byteSize: 16,
+            status: 'ready',
+          },
+        ],
+      },
+    ],
+    files: [],
+  };
+}
+
+function buildPersistOptions(overrides: Record<string, any> = {}): any {
+  return {
+    chatKey: 'test-chat',
+    isolationKey: 'default',
+    previousManifest: buildRollingManifest(),
+    rows: [{
+      rowKey: 'r1',
+      rowId: '1',
+      rowOrder: 0,
+      timeSpan: '上午',
+      location: '甲地',
+      summary: '第一次事件。',
+      indexCode: 'AM-0001',
+      vectorSourceText: '第一次事件。',
+      chunkIds: ['c1'],
+    }],
+    chunks: [{
+      chunkId: 'c1',
+      rowKey: 'r1',
+      text: '第一次事件。',
+      vector: [0.1, 0.2],
+      sequence: 0,
+    }],
+    snapshotMessageId: 'msg-1',
+    sourceTableKey: 'sheet_summary',
+    sourceTableName: '纪要表',
+    indexedAt: '2026-07-14T01:00:00.000Z',
+    skippedRowCount: 0,
+    embeddingModel: 'test-model',
+    snapshotRevision: 2,
+    ...overrides,
+  };
+}
+
+function uploadedRoles(): string[] {
+  return mockUpload.mock.calls.map(([params]: any[]) => params.role);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  missingPaths.clear();
+  mockGetCachedShard.mockResolvedValue(null);
+});
+
+describe('改动点 2：分片 404 记录与短路', () => {
+  it('读分片返回 404 时记录路径，且同会话第二次读取直接短路不再联网', async () => {
+    mockRead.mockResolvedValue({ ok: false, status: 404, error: '读取失败 404: Not Found' });
+    const manifest = buildRollingManifest();
+
+    await expect(loadSummaryVectorIndexChunksFromManifest_ACU(manifest))
+      .rejects.toThrow(/交火向量索引分片读取失败/);
+    expect(missingPaths.has(BASE_SHARD_PATH)).toBe(true);
+    expect(mockRead).toHaveBeenCalledTimes(1);
+
+    await expect(loadSummaryVectorIndexChunksFromManifest_ACU(manifest))
+      .rejects.toThrow(/已确认缺失\(404\)/);
+    expect(mockRead).toHaveBeenCalledTimes(1); // 未再次联网
+  });
+
+  it('非 404 的读取失败（如瞬时 500）不记录缺失，避免误触发强制折叠', async () => {
+    mockRead.mockResolvedValue({ ok: false, status: 500, error: '读取失败 500: Internal Server Error' });
+    const manifest = buildRollingManifest();
+
+    await expect(loadSummaryVectorIndexChunksFromManifest_ACU(manifest))
+      .rejects.toThrow(/交火向量索引分片读取失败/);
+    expect(missingPaths.has(BASE_SHARD_PATH)).toBe(false);
+  });
+});
+
+describe('改动点 1：base 确认缺失时强制折叠', () => {
+  it('base 完好且无变动行时不折叠（复用旧 base，不重写 base 分片）', async () => {
+    const result = await persistSummaryVectorIndexSnapshot_ACU(buildPersistOptions());
+    expect(uploadedRoles()).not.toContain('base_shard');
+    expect(result.manifest.snapshot?.mode).toBe('base_rolling_delta');
+  });
+
+  it('base 分片已确认缺失(404)时，即使变动行数远低于阈值也强制折叠重写 base', async () => {
+    missingPaths.add(BASE_SHARD_PATH);
+    const result = await persistSummaryVectorIndexSnapshot_ACU(buildPersistOptions());
+    expect(uploadedRoles()).toContain('base_shard');
+    // 折叠后新 base 上传成功，路径从缺失集合移除（上传成功分支）
+    const baseUpload = mockUpload.mock.calls.find(([params]: any[]) => params.role === 'base_shard');
+    expect(baseUpload).toBeTruthy();
+    expect(result.manifest.batchRefs?.some((batch: any) => batch.role === 'base' && batch.files.some((file: any) => file.role === 'base_shard'))).toBe(true);
+  });
+
+  it('闭环：先读 404（记录缺失）→ 随后归档强制折叠自愈', async () => {
+    mockRead.mockResolvedValue({ ok: false, status: 404, error: '读取失败 404: Not Found' });
+    await expect(loadSummaryVectorIndexChunksFromManifest_ACU(buildRollingManifest())).rejects.toThrow();
+    expect(missingPaths.has(BASE_SHARD_PATH)).toBe(true);
+
+    await persistSummaryVectorIndexSnapshot_ACU(buildPersistOptions());
+    expect(uploadedRoles()).toContain('base_shard');
+    // 新 base 上传成功后，其路径不在缺失集合中
+    const uploadedBasePaths = mockUpload.mock.calls
+      .filter(([params]: any[]) => params.role === 'base_shard')
+      .map(([params]: any[]) => params.path);
+    uploadedBasePaths.forEach((path: string) => expect(missingPaths.has(path)).toBe(false));
+  });
+});
+
+describe('改动点 4：折叠时 base 多分片写入', () => {
+  it('base chunks 超过 128 块时拆为 base_0001/base_0002 多分片', async () => {
+    const rowCount = 130;
+    const rows = Array.from({ length: rowCount }, (_, index) => ({
+      rowKey: `r${index + 1}`,
+      rowId: String(index + 1),
+      rowOrder: index,
+      timeSpan: '上午',
+      location: '甲地',
+      summary: `事件 ${index + 1}。`,
+      indexCode: `AM-${index + 1}`,
+      vectorSourceText: `事件 ${index + 1}。`,
+      chunkIds: [`c${index + 1}`],
+    }));
+    const chunks = rows.map((row, index) => ({
+      chunkId: `c${index + 1}`,
+      rowKey: row.rowKey,
+      text: row.summary,
+      vector: [0.1, 0.2],
+      sequence: index,
+    }));
+
+    await persistSummaryVectorIndexSnapshot_ACU(buildPersistOptions({
+      previousManifest: null, // 无可复用 base → 必然折叠
+      rows,
+      chunks,
+    }));
+
+    const baseShardIds = mockUpload.mock.calls
+      .filter(([params]: any[]) => params.role === 'base_shard')
+      .map(([params]: any[]) => params.shardId);
+    expect(baseShardIds).toEqual(['base_0001', 'base_0002']);
+    const baseChunkCounts = mockUpload.mock.calls
+      .filter(([params]: any[]) => params.role === 'base_shard')
+      .map(([params]: any[]) => params.chunkCount);
+    expect(baseChunkCounts).toEqual([128, 2]);
+  });
+});


### PR DESCRIPTION
## 问题                                                           
  开启 summaryIndexRollingDeltaEnabled 后,删楼若跨过最近一次折叠点, 
  最新剩余楼层会退回折叠点之前的旧层,其 base_shard 早在折叠时被     
  cleanup 删除 → 读取 404 → 交火召回失效,且每轮全量重嵌打满         
  embedding。                                                       
                                                                    
## 根因                                                           
  persistSummaryVectorIndexSnapshotAsRollingDelta_ACU 的 shouldFold 
  仅由                                                              
  「无可复用 base | base chunks 为空 | changedRowKeys >=            
  foldThreshold」触发。                                             
  删楼退回层自身行未变,三条件均不满足 → 永不折叠 → 死指针只写 delta,
  base 无法补回;同时 existingState.chunks 为空使                    
  buildExistingReusableRows_ACU                                     
  判定全行需重嵌,形成永久卡死 + 全量重嵌。

  ## 改动                                                           
  1. 会话级 404                                                     
  集合(vector-index-st-files-storage.ts):loadOneShardChunks_ACU     
     读到 status===404                                              
  记录路径并短路后续重试,uploadVectorIndexJsonFile_ACU              
     成功后移除。                                                   
  2. shouldFold 增加 baseFileConfirmedMissing:复用 base batch 命中  
  404 集合时                                                        
     无条件折叠重写,不受 foldThreshold 限制,一次自愈。              
  3. 折叠 base 按 DEFAULT_SHARD_CHUNK_LIMIT_ACU                     
  拆多分片写入,规避单大文件                                         
     上传截断;失败沿用 rollbackUploadedFiles_ACU 整体回滚。         
  4. hydrateAggregatedSummaryVectorIndexSnapshot_ACU                
  仅最新层与内容寻址层联网,                                         
     rolling 旧层跳过并加失败熔断,消除旧层 404 刷屏。  
                                                                    
## 测试                                                           
  新增 3 个测试覆盖 404 记录/短路、强制折叠自愈、base               
  多分片、hydrate 层级门控,                                         
  全量 pnpm test 通过。