### PR TITLE
perf(memory): 聊天消息缓存轻量化 + 摘要向量 Float32Array 化（降低长对话 GC 冻结）

### DIFF
--- a/src/data/storage/vector-index-hot-cache.ts
+++ b/src/data/storage/vector-index-hot-cache.ts
@@ -129,10 +129,25 @@ function openDb_ACU(): Promise<IDBDatabase> {
     });
 }
 
+// 摘要向量内存可能是 Float32Array（解码路径）或 number[]（IDB/元数据回读）。
+// IDB 序列化路径必须保持不变：写库前统一转回普通 number[]，避免结构化克隆把
+// Float32Array 落成不同形态，破坏既有缓存读取契约。
+function getChunkVector_ACU(chunk: ChatSummaryVectorIndexChunk_ACU | null | undefined): number[] | Float32Array | null {
+    if (Array.isArray(chunk?.vector)) return chunk!.vector;
+    if (chunk?.vector instanceof Float32Array) return chunk.vector;
+    return null;
+}
+
+function chunkVectorToNumberArray_ACU(chunk: ChatSummaryVectorIndexChunk_ACU | null | undefined): number[] {
+    const vector = getChunkVector_ACU(chunk);
+    if (!vector) return [];
+    return Array.from(vector, (value) => Number(value) || 0);
+}
+
 function cloneChunk_ACU(chunk: ChatSummaryVectorIndexChunk_ACU): ChatSummaryVectorIndexChunk_ACU {
     return {
         ...chunk,
-        vector: Array.isArray(chunk.vector) ? chunk.vector.map((value) => Number(value) || 0) : [],
+        vector: chunkVectorToNumberArray_ACU(chunk),
         chunkKeys: Array.isArray(chunk.chunkKeys) ? [...chunk.chunkKeys] : chunk.chunkKeys,
     };
 }
@@ -186,8 +201,8 @@ function isRecordCompatible_ACU(record: VectorIndexHotCacheChunkRecord_ACU | nul
     if (record.rowKey !== normalizeKeyPart_ACU(ref.rowKey)) return false;
     if (record.dimension !== Math.max(0, Number(ref.dimension) || 0)) return false;
     if (ref.checksum && record.checksum && record.checksum !== ref.checksum) return false;
-    const vector = Array.isArray(record.chunk.vector) ? record.chunk.vector : [];
-    return vector.length > 0 && (!ref.dimension || vector.length === ref.dimension);
+    const vector = getChunkVector_ACU(record.chunk);
+    return !!vector && vector.length > 0 && (!ref.dimension || vector.length === ref.dimension);
 }
 
 export async function putSummaryVectorHotCacheChunks_ACU(options: VectorIndexHotCacheWriteOptions_ACU): Promise<void> {
@@ -208,8 +223,8 @@ export async function putSummaryVectorHotCacheChunks_ACU(options: VectorIndexHot
                 const now = Date.now();
                 options.chunks.forEach((chunk) => {
                     const chunkId = normalizeKeyPart_ACU(chunk?.chunkId);
-                    const vector = Array.isArray(chunk?.vector) ? chunk.vector : [];
-                    if (!chunkId || vector.length === 0) return;
+                    const vector = getChunkVector_ACU(chunk);
+                    if (!chunkId || !vector || vector.length === 0) return;
                     const chunkKey = normalizeKeyPart_ACU((Array.isArray(chunk.chunkKeys) && chunk.chunkKeys[0]) || chunkId);
                     const normalizedChunk = cloneChunk_ACU({
                         ...chunk,
@@ -256,8 +271,8 @@ export async function putSummaryVectorHotCacheChunks_ACU(options: VectorIndexHot
             options.chunks.forEach((chunk) => {
                 const chunkId = normalizeKeyPart_ACU(chunk?.chunkId);
                 const ref = refsByChunkId.get(chunkId);
-                const vector = Array.isArray(chunk?.vector) ? chunk.vector : [];
-                if (!ref || vector.length === 0) return;
+                const vector = getChunkVector_ACU(chunk);
+                if (!ref || !vector || vector.length === 0) return;
                 const chunkKey = normalizeKeyPart_ACU(ref.chunkKey);
                 const normalizedChunk = cloneChunk_ACU({
                     ...chunk,

--- a/src/data/storage/vector-index-temp-cache.ts
+++ b/src/data/storage/vector-index-temp-cache.ts
@@ -81,13 +81,26 @@ export async function putVectorIndexCachedShard_ACU(
     checksum = '',
 ): Promise<void> {
     try {
-        const json = JSON.stringify(shard || {});
+        // 向量内存表示可能是 Float32Array（解码路径）。IDB 序列化路径保持不变：
+        // 写库前统一转回普通 number[]，避免结构化克隆改变既有缓存存储形态。
+        const normalizedShard: SummaryVectorIndexShard_ACU = {
+            ...shard,
+            chunks: Array.isArray(shard?.chunks)
+                ? shard.chunks.map((chunk) => ({
+                    ...chunk,
+                    vector: Array.isArray(chunk.vector) || chunk.vector instanceof Float32Array
+                        ? Array.from(chunk.vector as number[] | Float32Array, (value) => Number(value) || 0)
+                        : [],
+                }))
+                : [],
+        };
+        const json = JSON.stringify(normalizedShard);
         const now = Date.now();
         const record: CachedShardRecord_ACU = {
             key: makeKey_ACU(indexId, shardId),
             indexId,
             shardId,
-            shard,
+            shard: normalizedShard,
             byteSize: new Blob([json]).size,
             checksum,
             lastAccessAt: now,

--- a/src/service/vector/summary-vector-index-archive-service.ts
+++ b/src/service/vector/summary-vector-index-archive-service.ts
@@ -543,7 +543,9 @@ function buildExistingReusableRows_ACU(
     const existingChunks = Array.isArray(existingState?.chunks) ? existingState!.chunks : [];
     const existingChunksByRowKey = new Map<string, ChatSummaryVectorIndexChunk_ACU[]>();
     existingChunks.forEach((chunk) => {
-        if (!chunk?.rowKey || !chunk?.chunkId || !Array.isArray(chunk.vector) || chunk.vector.length === 0) return;
+        if (!chunk?.rowKey || !chunk?.chunkId
+            || (!Array.isArray(chunk.vector) && !(chunk.vector instanceof Float32Array))
+            || chunk.vector.length === 0) return;
         const list = existingChunksByRowKey.get(chunk.rowKey) || [];
         list.push({ ...chunk });
         existingChunksByRowKey.set(chunk.rowKey, list);
@@ -817,7 +819,9 @@ async function writeSummaryVectorIndexCheckpoint_ACU(options: {
     const validRowKeys = new Set(nextRows.map((row) => row.rowKey));
     const validChunkIds = new Set(nextRows.flatMap((row) => row.chunkIds));
     const nextChunks = Array.from(nextChunksById.values())
-        .filter((chunk) => validRowKeys.has(chunk.rowKey) && validChunkIds.has(chunk.chunkId) && Array.isArray(chunk.vector) && chunk.vector.length > 0)
+        .filter((chunk) => validRowKeys.has(chunk.rowKey) && validChunkIds.has(chunk.chunkId)
+            && (Array.isArray(chunk.vector) || chunk.vector instanceof Float32Array)
+            && chunk.vector.length > 0)
         .map((chunk, index) => ({ ...chunk, sequence: index }));
     const nextState = buildLayerStateWithRows_ACU(previousState, nextRows, nextChunks, {
         snapshotMessageId: options.snapshotMessageId,

--- a/src/service/vector/summary-vector-index-chat-service.ts
+++ b/src/service/vector/summary-vector-index-chat-service.ts
@@ -99,7 +99,11 @@ export async function tryRecoverSummaryVectorIndexFromExternalSnapshot_ACU(): Pr
             rows,
             chunks: chunks.map((chunk: any) => ({
                 ...chunk,
-                vector: Array.isArray(chunk.vector) ? chunk.vector.map((item: any) => Number(item)).filter((item: number) => Number.isFinite(item)) : [],
+                // 统一归一为普通 number[]：state.chunks 会随聊天元数据 JSON 序列化，
+                // 不能把 Float32Array 落进持久化路径。
+                vector: Array.isArray(chunk.vector) || chunk.vector instanceof Float32Array
+                    ? Array.from(chunk.vector as any, (item: any) => Number(item)).filter((item: number) => Number.isFinite(item))
+                    : [],
             })),
             manifest: JSON.parse(JSON.stringify(manifest)),
         };

--- a/src/service/vector/summary-vector-index-runtime.ts
+++ b/src/service/vector/summary-vector-index-runtime.ts
@@ -173,8 +173,8 @@ async function generateKeywords_ACU(config: any, userInput: string): Promise<str
 
 // T10：query 向量模长预计算。与 cosineSimilarity_ACU 内部的 leftNorm 算法逐位一致，
 // 外提后循环内不再重复累加 query 的平方和。
-function computeVectorNorm_ACU(vector: number[]): number {
-    if (!Array.isArray(vector) || vector.length <= 0) return 0;
+function computeVectorNorm_ACU(vector: number[] | Float32Array): number {
+    if ((!Array.isArray(vector) && !(vector instanceof Float32Array)) || vector.length <= 0) return 0;
     let norm = 0;
     for (const value of vector) {
         const num = Number(value) || 0;
@@ -186,8 +186,10 @@ function computeVectorNorm_ACU(vector: number[]): number {
 // T10：cosine 相似度，query 模长由调用方预计算传入（循环内只算点积与候选模长）。
 // T2：维度不一致直接返回 0，不再截断后照常打分——截断会把混维向量静默当成相似，
 // 产生错误召回且难以察觉。维度一致的路径与改动前逐项等价。
-function cosineSimilarity_ACU(left: number[], right: number[], leftNorm: number): number {
-    if (!Array.isArray(left) || !Array.isArray(right) || left.length !== right.length || left.length <= 0) return 0;
+function cosineSimilarity_ACU(left: number[] | Float32Array, right: number[] | Float32Array, leftNorm: number): number {
+    if ((!Array.isArray(left) && !(left instanceof Float32Array))
+        || (!Array.isArray(right) && !(right instanceof Float32Array))
+        || left.length !== right.length || left.length <= 0) return 0;
     const length = left.length;
     let dot = 0;
     let rightNorm = 0;
@@ -753,7 +755,7 @@ export async function processSummaryVectorIndexBeforeGeneration_ACU(
     // 否则保持原行为（空向量返回 empty_query_embedding；异常穿透给上层 init.ts 的 try/catch 兜底）。
     let keywords: string[] = [];
     let queryText = '';
-    let queryVector: number[] = [];
+    let queryVector: number[] | Float32Array = [];
     try {
         keywords = await generateKeywords_ACU(config, userInput);
         queryText = [userInput, keywords.join('，')].filter(Boolean).join('\n关键词：');
@@ -796,7 +798,7 @@ export async function processSummaryVectorIndexBeforeGeneration_ACU(
     const denseCandidates = searchableCandidates
         .map((candidate): RankedSummaryCandidate_ACU | null => {
             const chunk = candidate.chunk;
-            if (!Array.isArray(chunk.vector) || chunk.vector.length === 0) return null;
+            if ((!Array.isArray(chunk.vector) && !(chunk.vector instanceof Float32Array)) || chunk.vector.length === 0) return null;
             const score = cosineSimilarity_ACU(queryVector, chunk.vector, queryNorm);
             if (score < config.summaryIndexMinScore) return null;
             return { ...candidate, score, denseScore: score };

--- a/src/service/vector/summary-vector-index-state-service.ts
+++ b/src/service/vector/summary-vector-index-state-service.ts
@@ -55,7 +55,11 @@ function normalizeChunks_ACU(chunks: any): ChatSummaryVectorIndexChunk_ACU[] {
                 rowKey: String(chunk.rowKey || ''),
                 rowOrder: Number.isFinite(Number(chunk.rowOrder)) ? Number(chunk.rowOrder) : 0,
                 text: String(chunk.text || ''),
-                vector: Array.isArray(chunk.vector) ? chunk.vector.map((item: any) => Number(item)).filter((item: number) => Number.isFinite(item)) : [],
+                // 统一归一为普通 number[]：state.chunks 会随聊天元数据 JSON 序列化，
+                // 不能把 Float32Array 落进持久化路径。
+                vector: Array.isArray(chunk.vector) || chunk.vector instanceof Float32Array
+                    ? Array.from(chunk.vector as any, (item: any) => Number(item)).filter((item: number) => Number.isFinite(item))
+                    : [],
                 sequence: Number.isFinite(Number(chunk.sequence)) ? Number(chunk.sequence) : 0,
                 sourceFingerprint: typeof chunk.sourceFingerprint === 'string' ? chunk.sourceFingerprint : undefined,
                 textHash: typeof chunk.textHash === 'string' ? chunk.textHash : undefined,

--- a/src/service/vector/summary-vector-index-storage-service.ts
+++ b/src/service/vector/summary-vector-index-storage-service.ts
@@ -269,33 +269,44 @@ function normalizeRows_ACU(rows: ChatSummaryVectorIndexRow_ACU[]): ChatSummaryVe
 
 function normalizeChunks_ACU(chunks: ChatSummaryVectorIndexChunk_ACU[]): ChatSummaryVectorIndexChunk_ACU[] {
     return (Array.isArray(chunks) ? chunks : [])
-        .filter((chunk) => chunk?.chunkId && chunk?.rowKey && chunk?.text && Array.isArray(chunk.vector) && chunk.vector.length > 0)
+        .filter((chunk) => chunk?.chunkId && chunk?.rowKey && chunk?.text && isVectorLike_ACU(chunk.vector) && chunk.vector.length > 0)
         .map((chunk, index) => ({ ...chunk, sequence: index }));
 }
 
 const VECTOR_ENCODING_F32B64_ACU = 'f32b64' as const;
 
 type StoredVectorIndexChunk_ACU = Omit<ChatSummaryVectorIndexChunk_ACU, 'vector'> & {
-    vector: number[] | string;
+    vector: ChatSummaryVectorIndexChunk_ACU['vector'] | string;
     vectorEncoding?: typeof VECTOR_ENCODING_F32B64_ACU;
 };
 
 type StoredVectorIndexChunkBlob_ACU = Omit<VectorIndexChunkBlob_ACU, 'vector'> & {
-    vector: number[] | string;
+    vector: ChatSummaryVectorIndexChunk_ACU['vector'] | string;
     vectorEncoding?: typeof VECTOR_ENCODING_F32B64_ACU;
 };
 
-function encodeVectorToF32B64_ACU(vector: number[]): string {
-    if (!Array.isArray(vector)) return '';
+/** 摘要向量内存表示：Float32Array（解码）或 number[]（兼容旧内存数据）。 */
+function isVectorLike_ACU(value: unknown): value is number[] | Float32Array {
+    return Array.isArray(value) || value instanceof Float32Array;
+}
+
+/** 序列化边界用：把内存向量归一为普通 number[]，不改变落盘/IDB 数组格式。 */
+function vectorToFiniteNumberArray_ACU(vector: number[] | Float32Array | null | undefined): number[] {
+    if (!isVectorLike_ACU(vector)) return [];
+    return Array.from(vector, (value) => Number(value)).filter((value) => Number.isFinite(value));
+}
+
+function encodeVectorToF32B64_ACU(vector: number[] | Float32Array): string {
+    if (!isVectorLike_ACU(vector)) return '';
     const bytes = new Uint8Array(vector.length * 4);
     const view = new DataView(bytes.buffer);
-    vector.forEach((value, index) => {
-        const numeric = Number(value);
+    for (let index = 0; index < vector.length; index += 1) {
+        const numeric = Number(vector[index]);
         if (!Number.isFinite(numeric)) {
             throw new Error(`交火向量包含非有限数值，拒绝编码: index=${index}`);
         }
         view.setFloat32(index * 4, numeric, true);
-    });
+    }
     let binary = '';
     const blockSize = 0x8000;
     for (let offset = 0; offset < bytes.length; offset += blockSize) {
@@ -307,7 +318,7 @@ function encodeVectorToF32B64_ACU(vector: number[]): string {
     return encoder(binary);
 }
 
-function decodeF32B64ToVector_ACU(encoded: string): number[] {
+function decodeF32B64ToVector_ACU(encoded: string): Float32Array {
     const decoder = globalThis.atob;
     if (typeof decoder !== 'function') throw new Error('当前环境缺少 atob，无法解码交火向量。');
     const binary = decoder(String(encoded || ''));
@@ -317,8 +328,8 @@ function decodeF32B64ToVector_ACU(encoded: string): number[] {
     const bytes = new Uint8Array(binary.length);
     for (let i = 0; i < binary.length; i += 1) bytes[i] = binary.charCodeAt(i) & 0xff;
     const view = new DataView(bytes.buffer);
-    const vector: number[] = [];
-    for (let offset = 0; offset < bytes.length; offset += 4) vector.push(view.getFloat32(offset, true));
+    const vector = new Float32Array(bytes.length / 4);
+    for (let offset = 0; offset < bytes.length; offset += 4) vector[offset / 4] = view.getFloat32(offset, true);
     return vector;
 }
 
@@ -330,8 +341,9 @@ function decodeChunkVectorInPlace_ACU(chunk: StoredVectorIndexChunk_ACU): ChatSu
     if (chunk.vectorEncoding === VECTOR_ENCODING_F32B64_ACU || typeof chunk.vector === 'string') {
         chunk.vector = decodeF32B64ToVector_ACU(String(chunk.vector || ''));
         delete chunk.vectorEncoding;
-    } else if (Array.isArray(chunk.vector)) {
-        chunk.vector = chunk.vector.map((value) => Number(value)).filter((value) => Number.isFinite(value));
+    } else if (isVectorLike_ACU(chunk.vector)) {
+        // 旧内存 number[] → 统一为 Float32Array（内存表示迁移）。
+        chunk.vector = Float32Array.from(vectorToFiniteNumberArray_ACU(chunk.vector));
     }
     return chunk as ChatSummaryVectorIndexChunk_ACU;
 }
@@ -478,7 +490,7 @@ function buildVectorChunkBlob_ACU(chunk: ChatSummaryVectorIndexChunk_ACU, option
         rowKey: chunk.rowKey,
         rowOrder: Number.isFinite(Number((chunk as any).rowOrder)) ? Number((chunk as any).rowOrder) : 0,
         text: chunk.text,
-        vector: Array.isArray(chunk.vector) ? chunk.vector.map((item) => Number(item)).filter((item) => Number.isFinite(item)) : [],
+        vector: vectorToFiniteNumberArray_ACU(chunk.vector),
         sequence: Number.isFinite(Number(chunk.sequence)) ? Number(chunk.sequence) : 0,
         embeddingModel: options.embeddingModel,
         dimension: Math.max(0, Math.floor(Number(options.dimension) || 0)),
@@ -2084,7 +2096,7 @@ async function loadOneShardChunks_ACU(
     return (shard.chunks || [])
         .map((chunk) => ({ ...chunk, vector: Array.isArray(chunk.vector) ? [...chunk.vector] : chunk.vector } as StoredVectorIndexChunk_ACU))
         .map((chunk) => decodeChunkVectorInPlace_ACU(chunk))
-        .filter((chunk) => Array.isArray(chunk.vector) && chunk.vector.length > 0);
+        .filter((chunk) => isVectorLike_ACU(chunk.vector) && chunk.vector.length > 0);
 }
 
 async function loadChunksFromShardRefs_ACU(
@@ -2143,7 +2155,7 @@ async function loadChunksFromContentAddressedRefs_ACU(
             const message = error instanceof Error ? error.message : String(error || '未知错误');
             throw new Error(`交火向量索引内容块校验失败: ${sourcePath} chunk=${ref.chunkKey} ${message}`.trim());
         }
-        if (!Array.isArray(decoded.vector) || decoded.vector.length === 0) {
+        if (!isVectorLike_ACU(decoded.vector) || decoded.vector.length === 0) {
             throw new Error(`交火向量索引内容块校验失败: ${sourcePath} chunk=${ref.chunkKey} vector_empty`);
         }
         return decoded;
@@ -2222,7 +2234,7 @@ async function loadChunksFromContentAddressedRefs_ACU(
 function sortAndDedupeVectorChunks_ACU(chunks: ChatSummaryVectorIndexChunk_ACU[]): ChatSummaryVectorIndexChunk_ACU[] {
     const byChunkId = new Map<string, ChatSummaryVectorIndexChunk_ACU>();
     (Array.isArray(chunks) ? chunks : []).forEach((chunk) => {
-        if (!chunk?.chunkId || !chunk.rowKey || !Array.isArray(chunk.vector) || chunk.vector.length === 0) return;
+        if (!chunk?.chunkId || !chunk.rowKey || !isVectorLike_ACU(chunk.vector) || chunk.vector.length === 0) return;
         byChunkId.set(chunk.chunkId, { ...chunk });
     });
     // batchRefs 按 base -> delta 读取；相同 chunkId 必须让后出现的 delta 覆盖 base。

--- a/src/service/vector/summary-vector-index-types.ts
+++ b/src/service/vector/summary-vector-index-types.ts
@@ -30,7 +30,11 @@ export interface ChatSummaryVectorIndexChunk_ACU {
     rowKey: string;
     rowOrder: number;
     text: string;
-    vector: number[];
+    /**
+     * 内存表示以 Float32Array 为主（解码路径）；兼容旧 number[]（IDB 缓存、聊天元数据回读）。
+     * 磁盘格式（f32b64 字符串 / legacy number[]）保持不变。
+     */
+    vector: Float32Array | number[];
     sequence: number;
     sourceFingerprint?: string;
     textHash?: string;

--- a/src/service/worldbook/pipeline.ts
+++ b/src/service/worldbook/pipeline.ts
@@ -754,7 +754,7 @@ export   async function loadAllChatMessages_ACU() {
         include_swipes: false,
       });
       if (messagesFromApi && messagesFromApi.length > 0) {
-        _set_allChatMessages_ACU(messagesFromApi.map((msg, idx) => ({ ...msg, id: idx }))); // Add simple index for now
+        _set_allChatMessages_ACU(messagesFromApi.map((msg, idx) => ({ id: idx, is_user: msg.is_user, message: msg.message }))); // Projected lightweight view: only consumed fields retained
         logDebug_ACU(`ACU Loaded ${allChatMessages_ACU.length} messages for: ${currentChatFileIdentifier_ACU}.`);
       } else {
         _set_allChatMessages_ACU([]);

--- a/tests/service/vector/summary-vector-index-storage-service.test.ts
+++ b/tests/service/vector/summary-vector-index-storage-service.test.ts
@@ -130,7 +130,7 @@ describe('summary-vector-index-storage-service V2 单文件读取', () => {
     const manifest = manifest_ACU();
     h.read.mockResolvedValue({ ok: true, data: blob_ACU(manifest) });
 
-    await expect(loadSummaryVectorIndexChunksFromManifest_ACU(manifest, { preferExternalFiles: true })).resolves.toMatchObject([{ chunkId: 'chunk-a', vector: [1, 2] }]);
+    await expect(loadSummaryVectorIndexChunksFromManifest_ACU(manifest, { preferExternalFiles: true })).resolves.toMatchObject([{ chunkId: 'chunk-a', vector: new Float32Array([1, 2]) }]);
     expect(h.read).toHaveBeenCalledWith(manifest.manifestFile);
     // V2 不可变快照：不查缓存、不回填缓存
     expect(h.getHot).not.toHaveBeenCalled();
@@ -143,7 +143,7 @@ describe('summary-vector-index-storage-service V2 单文件读取', () => {
     h.read.mockResolvedValue({ ok: true, data: blob_ACU(manifest) });
 
     await expect(loadSummaryVectorIndexChunksFromManifest_ACU(manifest))
-      .resolves.toMatchObject([{ chunkId: 'chunk-a', vector: [1, 2] }]);
+      .resolves.toMatchObject([{ chunkId: 'chunk-a', vector: new Float32Array([1, 2]) }]);
     // 即使缓存有数据，V2 不可变快照也直接回源，不查询缓存
     expect(h.getHot).not.toHaveBeenCalled();
     expect(h.read).toHaveBeenCalledTimes(1);
@@ -156,7 +156,7 @@ describe('summary-vector-index-storage-service V2 单文件读取', () => {
     h.read.mockResolvedValue({ ok: true, data: blob_ACU(manifest) });
 
     await expect(loadSummaryVectorIndexChunksFromManifest_ACU(manifest))
-      .resolves.toMatchObject([{ chunkId: 'chunk-a', vector: [1, 2] }]);
+      .resolves.toMatchObject([{ chunkId: 'chunk-a', vector: new Float32Array([1, 2]) }]);
     expect(h.getHot).not.toHaveBeenCalled();
     expect(h.read).toHaveBeenCalledWith(manifest.manifestFile);
     expect(h.putHot).not.toHaveBeenCalled();
@@ -169,7 +169,7 @@ describe('summary-vector-index-storage-service V2 单文件读取', () => {
     h.read.mockResolvedValue({ ok: true, data: blob_ACU(manifest) });
 
     await expect(loadSummaryVectorIndexChunksFromManifest_ACU(manifest, { preferExternalFiles: true }))
-      .resolves.toMatchObject([{ chunkId: 'chunk-a', vector: [1, 2] }]);
+      .resolves.toMatchObject([{ chunkId: 'chunk-a', vector: new Float32Array([1, 2]) }]);
     expect(h.getHot).not.toHaveBeenCalled();
     expect(h.read).toHaveBeenCalledWith(manifest.manifestFile);
   });
@@ -180,7 +180,7 @@ describe('summary-vector-index-storage-service V2 单文件读取', () => {
     h.read.mockResolvedValue({ ok: true, data: blob_ACU(manifest) });
 
     await expect(loadSummaryVectorIndexChunksFromManifest_ACU(manifest, { preferExternalFiles: true }))
-      .resolves.toMatchObject([{ chunkId: 'chunk-a', vector: [1, 2] }]);
+      .resolves.toMatchObject([{ chunkId: 'chunk-a', vector: new Float32Array([1, 2]) }]);
 
     expect(h.read).toHaveBeenCalledWith(manifest.manifestFile);
   });
@@ -224,7 +224,7 @@ describe('summary-vector-index-storage-service V2 单文件读取', () => {
     h.read.mockResolvedValue({ ok: true, data: blob });
 
     await expect(loadSummaryVectorIndexChunksFromManifest_ACU(manifest, { preferExternalFiles: true }))
-      .resolves.toMatchObject([{ chunkId: 'chunk-a', vector: [1, 2] }]);
+      .resolves.toMatchObject([{ chunkId: 'chunk-a', vector: new Float32Array([1, 2]) }]);
   });
 
   it('legacy 默认隔离域兼容 manifest=default 与 blob 空 isolationKey', async () => {
@@ -238,7 +238,7 @@ describe('summary-vector-index-storage-service V2 单文件读取', () => {
     h.read.mockResolvedValue({ ok: true, data: blob });
 
     await expect(loadSummaryVectorIndexChunksFromManifest_ACU(manifest, { preferExternalFiles: true }))
-      .resolves.toMatchObject([{ chunkId: 'chunk-a', vector: [1, 2] }]);
+      .resolves.toMatchObject([{ chunkId: 'chunk-a', vector: new Float32Array([1, 2]) }]);
     expect(h.putHot).toHaveBeenCalled();
   });
 


### PR DESCRIPTION
# 性能优化：降低运行时内存占用（消息缓存轻量化 + 摘要向量 Float32Array 化）

## 背景

长对话场景下，插件所在标签页 V8 堆增长至 ~5GB，触发大 GC 风暴导致主线程冻结数分钟（实测采样：渲染进程 CPU 持续 137%~182%，堆在 3.9→5.0GB 间锯齿波动）。用户侧磁盘 IndexedDB 仅 ~255MB，运行时放大 ~20x。

定位到的主要放大器（按权重）：
1. 每次写后全量 `SELECT *` 导出并整体替换 `currentJsonTableData_ACU`（`sql-table-service.ts` `_syncToJson`）
2. 全聊天历史含重字段完整驻留 `allChatMessages_ACU`（`pipeline.ts:757`），加上 ST 原生 chat / `currentJsonTableData_ACU` / sql.js WASM 堆共 4 份常驻副本
3. 每个 AI 响应 `new SqliteEngine()` 整库灌入→导出→销毁（`sql-table-service.ts:2041-2144`）
4. 摘要向量以 `number[]` 全量驻留 + 每次请求全量暴力余弦/BM25

本 PR 只处理其中**纯运行时表示**的两处，不触碰任何持久化格式。

## 改动 1：`allChatMessages_ACU` 投影轻量化

`src/service/worldbook/pipeline.ts:757`，驻留时由完整消息对象改为只保留被消费的字段：

```ts
// before
_set_allChatMessages_ACU(messagesFromApi.map((msg, idx) => ({ ...msg, id: idx })));
// after
_set_allChatMessages_ACU(messagesFromApi.map((msg, idx) => ({ id: idx, is_user: msg.is_user, message: msg.message })));
```

全库复核消费点：仅 `length`（settings-ui-trigger.ts:133）、`is_user`（:138）、`message`（pipeline.ts:1430 fallbackScanText）三处实际读字段，投影安全。该数组为运行时缓存不落盘，原始数据仍在服务端聊天中。长对话下此项节省 GB 级常驻内存。

## 改动 2：摘要向量内存表示 `number[]` → `Float32Array`

- `decodeF32B64ToVector_ACU` 返回 `Float32Array`；`encodeVectorToF32B64_ACU` 入参兼容两种形态（索引循环编码）
- 类型 `ChatSummaryVectorIndexChunk_ACU.vector` 扩为 `Float32Array | number[]`
- `cosineSimilarity_ACU` / `computeVectorNorm_ACU` / 余弦扫描 / archive 过滤守卫放行 Float32Array
- legacy `number[]` chunk 解码后统一 `Float32Array.from(...)` 归一

**存储边界保证**（格式逐位不变，新旧版本可无损互切）：
- IndexedDB 写入前经 `chunkVectorToNumberArray_ACU` / `normalizedShard` 转回普通 `number[]`（hot-cache、temp-cache 两处），结构化克隆落库形态与改动前一致
- 聊天元数据 JSON 路径（state-service / chat-service 归一化）仍产出 `number[]`
- 磁盘 f32b64 字符串与 legacy blob 格式未触碰

收益：向量内存约省一半（8B/dim → 4B/dim），且连续 typed array 显著降低 GC 标记成本。

## 尝试过但主动放弃的改动（供参考）

曾尝试让 `getCurrentData` 返回 `currentJsonTableData_ACU` 深拷贝以消除每次读的全量导出，实测失败：返回值被 `update-orchestrator.ts:301` → `captureSqlTableApplyScope_ACU` → `freezeRuntimeSchemaFromData_ACU` 用于 schema digest 冻结，依赖 SQLite 导出时附加的 **non-enumerable `_acu_runtimeEffectiveSchema` descriptor**；JSON 深拷贝会剥离该 descriptor，导致冻结返回 null、`applyEditsWithSystemRowIds` 的 fail-closed 门失效（2 个测试失败）。已回滚。若未来优化此读路径，建议将 runtime schema 信息显式化（如 WeakMap 旁路）。

## 后续可优化方向（未包含在本 PR）

- 写后全量导出 → 脏标记 + 按表导出（`modifiedTableNames` 写路径中已有）
- 每 AI 响应重建引擎 → SAVEPOINT 快照复用
- checkpoint 每层全量快照 → 增量 + 周期压实（涉及存储格式演进）
- sql.js → OPFS SyncAccessHandle 流式（需 COOP/COEP，架构级）

## 验证

- `npx tsc --noEmit`：0 错误
- 全量 `npx vitest run`：**6541 passed / 28 skipped / 0 failed**（294 文件）
- `npx rollup -c` 构建通过（构建产物未包含在本 PR 中，仅源码改动；涉及测试断言 7 处同步更新为 `new Float32Array([...])`）
