### PR TITLE
feat: API 预设新增「接口协议」四选一——TT custom_api_format 契约 + 原版 ST 原生协议源双宿主适配

### DIFF
--- a/src/presentation-v2/components/ApiConfigPanel.vue
+++ b/src/presentation-v2/components/ApiConfigPanel.vue
@@ -53,6 +53,16 @@
         </AcuFormRow>
 
         <template v-if="activeConnectionMode === 'custom'">
+          <AcuFormRow
+            label="接口协议"
+            hint="决定请求变形与上游端点：兼容 OpenAI→/chat/completions；兼容 OpenAI Responses→/responses；兼容 Claude Messages→/messages；兼容 Gemini Interactions→/interactions（自动补 /v1beta）。默认兼容 OpenAI。注意：纯原生端点下「加载模型」可能失败，可手填模型名。"
+          >
+            <AcuSelect
+              :options="customApiFormatOptions"
+              :model-value="activeDraft.customApiFormat"
+              @update:model-value="activeDraft.customApiFormat = $event"
+            />
+          </AcuFormRow>
           <AcuFormRow label="端点(基础URL)">
             <AcuInput
               v-model="activeDraft.url"
@@ -239,6 +249,13 @@ const connectionModeOptions: AcuSegmentedOption[] = [
   { value: "main", label: "酒馆主 API" },
   { value: "custom", label: "自定义" },
   { value: "tavern", label: "酒馆预设" },
+];
+// ─── 接口协议选项（对齐 TT 主 API 四个「自定义」选项，custom_api_format 契约） ───
+const customApiFormatOptions: AcuSelectOption[] = [
+  { value: "openai_compat", label: "兼容 OpenAI" },
+  { value: "openai_responses", label: "兼容 OpenAI Responses" },
+  { value: "claude_messages", label: "兼容 Claude Messages" },
+  { value: "gemini_interactions", label: "兼容 Gemini Interactions" },
 ];
 const modelSelectOptions = computed<AcuSelectOption[]>(() =>
   store.modelOptions.map((m) => ({ value: m, label: m })),

--- a/src/presentation-v2/components/ApiConfigPanel.vue
+++ b/src/presentation-v2/components/ApiConfigPanel.vue
@@ -55,7 +55,7 @@
         <template v-if="activeConnectionMode === 'custom'">
           <AcuFormRow
             label="接口协议"
-            hint="决定请求变形与上游端点。TauriTavern：custom_api_format 契约分流——兼容 OpenAI→/chat/completions；兼容 OpenAI Responses→/responses；兼容 Claude Messages→/messages；兼容 Gemini Interactions→/interactions（自动补 /v1beta）。原版 SillyTavern：Claude/Gemini 映射到服务端原生协议源（需端点填协议根地址，如 https://api.anthropic.com；Responses 无对应后端，回退兼容 OpenAI）。默认兼容 OpenAI。注意：纯原生端点下「加载模型」可能失败，可手填模型名。"
+            hint="决定请求变形与上游端点。TauriTavern：custom_api_format 契约分流——兼容 OpenAI→/chat/completions；兼容 OpenAI Responses→/responses；兼容 Claude Messages→/messages；兼容 Gemini Interactions→/interactions（自动补 /v1beta）。原版 SillyTavern：Claude/Gemini 映射到服务端原生协议源，端点填协议根即可（插件自动按 ST 拼接语义归一：Claude 补 /v1、Gemini 剥版本段；Responses 无对应后端，回退兼容 OpenAI）。默认兼容 OpenAI。注意：纯原生端点下「加载模型」可能失败，可手填模型名。"
           >
             <AcuSelect
               :options="customApiFormatOptions"

--- a/src/presentation-v2/components/ApiConfigPanel.vue
+++ b/src/presentation-v2/components/ApiConfigPanel.vue
@@ -55,7 +55,7 @@
         <template v-if="activeConnectionMode === 'custom'">
           <AcuFormRow
             label="接口协议"
-            hint="决定请求变形与上游端点：兼容 OpenAI→/chat/completions；兼容 OpenAI Responses→/responses；兼容 Claude Messages→/messages；兼容 Gemini Interactions→/interactions（自动补 /v1beta）。默认兼容 OpenAI。注意：纯原生端点下「加载模型」可能失败，可手填模型名。"
+            hint="决定请求变形与上游端点。TauriTavern：custom_api_format 契约分流——兼容 OpenAI→/chat/completions；兼容 OpenAI Responses→/responses；兼容 Claude Messages→/messages；兼容 Gemini Interactions→/interactions（自动补 /v1beta）。原版 SillyTavern：Claude/Gemini 映射到服务端原生协议源（需端点填协议根地址，如 https://api.anthropic.com；Responses 无对应后端，回退兼容 OpenAI）。默认兼容 OpenAI。注意：纯原生端点下「加载模型」可能失败，可手填模型名。"
           >
             <AcuSelect
               :options="customApiFormatOptions"

--- a/src/presentation-v2/composables/useApiPresetManagement.ts
+++ b/src/presentation-v2/composables/useApiPresetManagement.ts
@@ -13,6 +13,8 @@ export interface ApiPresetDraft {
   bodyParams: string;
   excludeBodyParams: string;
   requestHeaders: string;
+  /** 接口协议（预设级）：openai_compat / openai_responses / claude_messages / gemini_interactions */
+  customApiFormat: string;
 }
 
 /** Effective connection mode — flattens apiMode + useMainApi into 3 user-visible states. */
@@ -50,6 +52,7 @@ export function createEmptyApiPresetDraft(): ApiPresetDraft {
     bodyParams: '',
     excludeBodyParams: '',
     requestHeaders: '',
+    customApiFormat: 'openai_compat',
   };
 }
 
@@ -67,6 +70,7 @@ export function apiPresetDraftFromPreset(preset: AcuV2ApiPreset): ApiPresetDraft
     bodyParams: preset.apiConfig.bodyParams || '',
     excludeBodyParams: preset.apiConfig.excludeBodyParams || '',
     requestHeaders: preset.apiConfig.requestHeaders || '',
+    customApiFormat: preset.apiConfig.customApiFormat || 'openai_compat',
   };
 }
 
@@ -85,6 +89,9 @@ export function apiPresetFromDraft(draft: ApiPresetDraft): AcuV2ApiPreset {
       bodyParams: draft.bodyParams || '',
       excludeBodyParams: draft.excludeBodyParams || '',
       requestHeaders: draft.requestHeaders || '',
+      customApiFormat: (['openai_compat', 'openai_responses', 'claude_messages', 'gemini_interactions'] as const).includes(draft.customApiFormat as any)
+        ? (draft.customApiFormat as 'openai_compat' | 'openai_responses' | 'claude_messages' | 'gemini_interactions')
+        : 'openai_compat',
     },
   };
 }

--- a/src/service/ai/api-call.ts
+++ b/src/service/ai/api-call.ts
@@ -187,6 +187,14 @@ export function buildCustomApiRequestBody_ACU(
     top_p: topP,
     stream: streaming,
     chat_completion_source: 'custom',
+    // 接口协议（预设级）：对齐 TauriTavern 主 API 四「自定义」选项（custom_api_format 契约）。
+    // 后端按该值分流上游端点与请求/响应变形：openai_compat→/chat/completions、
+    // openai_responses→/responses、claude_messages→/messages、gemini_interactions→/interactions；
+    // 非流式响应归一化为 OpenAI 形态，流式 Claude 为原样 Anthropic SSE（解析见 prompt-api-call）。
+    // 白名单兜底：调用点可能传未归一化的 config，非法值回退 openai_compat。
+    custom_api_format: (['openai_compat', 'openai_responses', 'claude_messages', 'gemini_interactions'] as const).includes(effectiveApiConfig.customApiFormat)
+      ? effectiveApiConfig.customApiFormat
+      : 'openai_compat',
     group_names: [],
     include_reasoning: false,
     reasoning_effort: 'medium',

--- a/src/service/ai/api-call.ts
+++ b/src/service/ai/api-call.ts
@@ -7,6 +7,7 @@ export type { AiUsageMetadata_ACU };
 import { settings_ACU } from '../runtime/state-manager';
 import { isGenerateRawAvailable_ACU, generateRaw_ACU, sendConnectionManagerRequest_ACU, getHostRequestHeaders_ACU, getConnectionManagerProfiles_ACU, triggerSlash_ACU } from '../../data/gateways/ai-gateway';
 import { logDebug_ACU, logWarn_ACU } from '../../shared/utils';
+import { isTauriTavernHost_ACU } from '../../shared/host-detect';
 import { resolveApiConfigByPreset_ACU, type ApiPresetApiConfig_ACU, type ApiPresetApiMode_ACU } from '../settings/api-preset-service';
 
 type CustomIncludeBodyRootType_ACU = 'empty' | 'mapping' | 'sequence' | 'scalar' | 'invalid';
@@ -158,6 +159,25 @@ export function buildCustomApiRequestBody_ACU(
     logWarn_ACU('[buildCustomApiRequestBody] 用户 stream_options 不是对象，已由插件对象替换', composedIncludeBody.diagnostic);
   }
 
+  // 接口协议按宿主后端形态分流（同一预设字段 customApiFormat，两种落地方式）：
+  // - TauriTavern（Rust 后端）：透传 custom_api_format 契约，按其分流上游端点与请求/响应变形
+  //   （openai_compat→/chat/completions、openai_responses→/responses、claude_messages→/messages、
+  //   gemini_interactions→/interactions）；非流式响应归一化为 OpenAI 形态，流式 Claude 为原样 Anthropic SSE。
+  // - 原版 SillyTavern（Node 后端）：不识别 custom_api_format，改为映射到其内置的原生协议源
+  //   （claude_messages→chat_completion_source:'claude'，服务端做 Anthropic 变形并透传原生 SSE，
+  //   gemini_interactions→'makersuite'）；openai_compat 维持 custom；
+  //   openai_responses 在 ST 无对应后端，回退 custom（/chat/completions）。
+  // 白名单兜底：调用点可能传未归一化的 config，非法值回退 openai_compat。
+  const CUSTOM_API_FORMATS_ACU = ['openai_compat', 'openai_responses', 'claude_messages', 'gemini_interactions'] as const;
+  const customApiFormat = CUSTOM_API_FORMATS_ACU.includes(effectiveApiConfig.customApiFormat)
+    ? effectiveApiConfig.customApiFormat
+    : 'openai_compat';
+  const isTauriTavern_ACU = isTauriTavernHost_ACU();
+  const ST_NATIVE_SOURCE_BY_FORMAT: Record<string, string> = { claude_messages: 'claude', gemini_interactions: 'makersuite' };
+  const chatCompletionSource = isTauriTavern_ACU || !ST_NATIVE_SOURCE_BY_FORMAT[customApiFormat]
+    ? 'custom'
+    : ST_NATIVE_SOURCE_BY_FORMAT[customApiFormat];
+
   const body: Record<string, any> = {
     // 统一将 messages 的 role 归一为小写（system / user / assistant）。
     //
@@ -186,15 +206,9 @@ export function buildCustomApiRequestBody_ACU(
     temperature,
     top_p: topP,
     stream: streaming,
-    chat_completion_source: 'custom',
-    // 接口协议（预设级）：对齐 TauriTavern 主 API 四「自定义」选项（custom_api_format 契约）。
-    // 后端按该值分流上游端点与请求/响应变形：openai_compat→/chat/completions、
-    // openai_responses→/responses、claude_messages→/messages、gemini_interactions→/interactions；
-    // 非流式响应归一化为 OpenAI 形态，流式 Claude 为原样 Anthropic SSE（解析见 prompt-api-call）。
-    // 白名单兜底：调用点可能传未归一化的 config，非法值回退 openai_compat。
-    custom_api_format: (['openai_compat', 'openai_responses', 'claude_messages', 'gemini_interactions'] as const).includes(effectiveApiConfig.customApiFormat)
-      ? effectiveApiConfig.customApiFormat
-      : 'openai_compat',
+    chat_completion_source: chatCompletionSource,
+    // custom_api_format 为 TT 契约字段，仅在 TT 宿主下携带（ST 后端不识别，由上方映射到原生源）。
+    ...(isTauriTavern_ACU ? { custom_api_format: customApiFormat } : {}),
     group_names: [],
     include_reasoning: false,
     reasoning_effort: 'medium',
@@ -202,7 +216,11 @@ export function buildCustomApiRequestBody_ACU(
     request_images: false,
     custom_prompt_post_processing: 'strict',
     reverse_proxy: effectiveApiConfig.url,
-    proxy_password: '',
+    // 原版 ST 原生协议源（claude/makersuite）从 reverse_proxy+proxy_password 取预设地址与密钥；
+    // custom 源与 TT 不使用该字段，保持空串。
+    proxy_password: (!isTauriTavern_ACU && chatCompletionSource !== 'custom')
+      ? String(effectiveApiConfig.apiKey || '')
+      : '',
     custom_url: effectiveApiConfig.url,
     custom_include_headers: headers,
     custom_include_body: composedIncludeBody.value,

--- a/src/service/ai/api-call.ts
+++ b/src/service/ai/api-call.ts
@@ -98,6 +98,33 @@ function normalizeExcludeBodyParamsForSillyTavern_ACU(raw: any): string {
 }
 
 /**
+ * 原版 ST 原生协议源的 reverse_proxy 基址归一化（对齐 ST 自身的 URL 拼接语义）：
+ * - claude 源 fetch(apiUrl + '/messages')：基址须含 /v1（ST 官方常量即 https://api.anthropic.com/v1）；
+ * - makersuite 源 fetch(`${apiUrl}/${apiVersion}/models/...`)：基址不得带版本段（服务端自补 /v1beta）。
+ * 仅剥显式协议路径段（/messages、/v1beta 等防重复），并按 ST 惯例补 /v1，
+ * 不改写用户自建代理的其他子路径段（如 https://gw.example.com/claude 视为用户有意为之）。
+ */
+export function normalizeSTNativeProxyBase_ACU(rawUrl: unknown, nativeSource: 'claude' | 'makersuite'): string {
+  let base = String(rawUrl || '').trim().replace(/\/+$/, '');
+  if (!base) return '';
+  for (const suffix of ['/chat/completions', '/messages', '/responses', '/interactions']) {
+    if (base.endsWith(suffix)) { base = base.slice(0, -suffix.length).replace(/\/+$/, ''); break; }
+  }
+  if (nativeSource === 'claude') {
+    if (base.endsWith('/v1beta')) base = base.slice(0, -'/v1beta'.length).replace(/\/+$/, '');
+    let path = '';
+    try { path = new URL(base).pathname.replace(/\/+$/, ''); } catch { /* 非法 URL 原样透传，交由后端报错 */ }
+    if (path === '' || path === '/') return `${base}/v1`;
+    if (!base.endsWith('/v1')) return `${base}/v1`;
+    return base;
+  }
+  for (const suffix of ['/v1beta', '/v1']) {
+    if (base.endsWith(suffix)) { base = base.slice(0, -suffix.length).replace(/\/+$/, ''); break; }
+  }
+  return base;
+}
+
+/**
  * 构建 Chat Completions 自定义 API 请求体（支持 bodyParams / excludeBodyParams / requestHeaders）
  */
 export function buildCustomApiRequestBody_ACU(
@@ -177,6 +204,12 @@ export function buildCustomApiRequestBody_ACU(
   const chatCompletionSource = isTauriTavern_ACU || !ST_NATIVE_SOURCE_BY_FORMAT[customApiFormat]
     ? 'custom'
     : ST_NATIVE_SOURCE_BY_FORMAT[customApiFormat];
+  const stNativeSource = (!isTauriTavern_ACU && chatCompletionSource !== 'custom')
+    ? (chatCompletionSource as 'claude' | 'makersuite')
+    : null;
+  const reverseProxy = stNativeSource
+    ? normalizeSTNativeProxyBase_ACU(effectiveApiConfig.url, stNativeSource)
+    : effectiveApiConfig.url;
 
   const body: Record<string, any> = {
     // 统一将 messages 的 role 归一为小写（system / user / assistant）。
@@ -215,10 +248,11 @@ export function buildCustomApiRequestBody_ACU(
     enable_web_search: false,
     request_images: false,
     custom_prompt_post_processing: 'strict',
-    reverse_proxy: effectiveApiConfig.url,
+    reverse_proxy: reverseProxy,
     // 原版 ST 原生协议源（claude/makersuite）从 reverse_proxy+proxy_password 取预设地址与密钥；
-    // custom 源与 TT 不使用该字段，保持空串。
-    proxy_password: (!isTauriTavern_ACU && chatCompletionSource !== 'custom')
+    // reverse_proxy 已按 ST 拼接语义归一化（claude 补 /v1、makersuite 剥版本段）。
+    // custom 源与 TT 不使用该字段，proxy_password 保持空串。
+    proxy_password: stNativeSource
       ? String(effectiveApiConfig.apiKey || '')
       : '',
     custom_url: effectiveApiConfig.url,

--- a/src/service/ai/prompt-builder/prompt-api-call.ts
+++ b/src/service/ai/prompt-builder/prompt-api-call.ts
@@ -492,6 +492,11 @@ export class RetryableAiResponseError_ACU extends Error {
                         if (content) {
                             fullContent += content;
                         }
+                        // Anthropic SSE 分支（接口协议=claude_messages 时后端原样透传 Anthropic 流，不归一化）：
+                        // content_block_delta(text_delta).delta.text 拼内容；message_stop 视为流结束（等价 [DONE]）。
+                        if (json?.type === 'content_block_delta' && json?.delta?.type === 'text_delta' && typeof json?.delta?.text === 'string') {
+                            fullContent += json.delta.text;
+                        }
                         const usage = extractResponseUsageMetadata_ACU(json);
                         capturedUsage = mergeAiUsageMetadata_ACU(capturedUsage, usage);
                     } catch (e) {

--- a/src/service/ai/prompt-builder/prompt-api-call.ts
+++ b/src/service/ai/prompt-builder/prompt-api-call.ts
@@ -497,6 +497,16 @@ export class RetryableAiResponseError_ACU extends Error {
                         if (json?.type === 'content_block_delta' && json?.delta?.type === 'text_delta' && typeof json?.delta?.text === 'string') {
                             fullContent += json.delta.text;
                         }
+                        // Gemini SSE 分支（接口协议=gemini_interactions 时后端原样透传 generateContent 流）：
+                        // candidates[0].content.parts[].text 拼接（跳过 thought 段）；流结束由连接关闭界定。
+                        const geminiParts = json?.candidates?.[0]?.content?.parts;
+                        if (Array.isArray(geminiParts)) {
+                            for (const part of geminiParts) {
+                                if (part && typeof part.text === 'string' && part.thought !== true) {
+                                    fullContent += part.text;
+                                }
+                            }
+                        }
                         const usage = extractResponseUsageMetadata_ACU(json);
                         capturedUsage = mergeAiUsageMetadata_ACU(capturedUsage, usage);
                     } catch (e) {

--- a/src/service/settings/api-preset-service.ts
+++ b/src/service/settings/api-preset-service.ts
@@ -35,7 +35,7 @@ export interface ApiPresetApiConfig_ACU {
   bodyParams: string;
   excludeBodyParams: string;
   requestHeaders: string;
-  /** 接口协议（预设级）：openai_compat（默认）/ openai_responses / claude_messages / gemini_interactions；随请求体 custom_api_format 透传给后端分流 */
+  /** 接口协议（预设级）：openai_compat（默认）/ openai_responses / claude_messages / gemini_interactions；TT 下随请求体 custom_api_format 透传分流，原版 ST 下映射为原生 chat_completion_source（claude/makersuite） */
   customApiFormat: CustomApiFormat_ACU;
 }
 

--- a/src/service/settings/api-preset-service.ts
+++ b/src/service/settings/api-preset-service.ts
@@ -14,6 +14,16 @@ import { logWarn_ACU } from '../../shared/utils';
 
 export type ApiPresetApiMode_ACU = 'custom' | 'tavern';
 
+/** 接口协议（预设级）：对齐 TauriTavern 主 API 的四个「自定义」选项（custom_api_format 四值契约） */
+export type CustomApiFormat_ACU = 'openai_compat' | 'openai_responses' | 'claude_messages' | 'gemini_interactions';
+
+const CUSTOM_API_FORMATS_ACU: readonly CustomApiFormat_ACU[] = ['openai_compat', 'openai_responses', 'claude_messages', 'gemini_interactions'];
+
+export function normalizeCustomApiFormat_ACU(value: unknown): CustomApiFormat_ACU {
+  const raw = String(value ?? '').trim();
+  return (CUSTOM_API_FORMATS_ACU as readonly string[]).includes(raw) ? (raw as CustomApiFormat_ACU) : 'openai_compat';
+}
+
 export interface ApiPresetApiConfig_ACU {
   url: string;
   apiKey: string;
@@ -25,6 +35,8 @@ export interface ApiPresetApiConfig_ACU {
   bodyParams: string;
   excludeBodyParams: string;
   requestHeaders: string;
+  /** 接口协议（预设级）：openai_compat（默认）/ openai_responses / claude_messages / gemini_interactions；随请求体 custom_api_format 透传给后端分流 */
+  customApiFormat: CustomApiFormat_ACU;
 }
 
 export interface ApiPreset_ACU {
@@ -72,9 +84,10 @@ export function normalizeApiConfig_ACU(value: any): ApiPresetApiConfig_ACU {
     bodyParams: typeof source.bodyParams === 'string' ? source.bodyParams : '',
     excludeBodyParams: typeof source.excludeBodyParams === 'string' ? source.excludeBodyParams : '',
     requestHeaders: typeof source.requestHeaders === 'string' ? source.requestHeaders : '',
+    customApiFormat: normalizeCustomApiFormat_ACU(source.customApiFormat),
     ...Object.fromEntries(
       Object.entries(source).filter(([key]) =>
-        !['url', 'apiKey', 'model', 'useMainApi', 'max_tokens', 'maxTokens', 'temperature', 'bodyParams', 'excludeBodyParams', 'requestHeaders'].includes(key)
+        !['url', 'apiKey', 'model', 'useMainApi', 'max_tokens', 'maxTokens', 'temperature', 'bodyParams', 'excludeBodyParams', 'requestHeaders', 'customApiFormat'].includes(key)
       )
     ),
   };

--- a/src/shared/host-detect.ts
+++ b/src/shared/host-detect.ts
@@ -1,0 +1,16 @@
+/**
+ * shared/host-detect.ts — 宿主后端形态检测
+ *
+ * 区分 TauriTavern（Rust 后端，支持 custom_api_format 契约）与原版 SillyTavern
+ * （Node 后端，按 chat_completion_source 内置原生协议转换）。
+ * 每次调用时判定（不缓存），与 TT ABI 检测惯例一致（window.__TAURITAVERN__，
+ * 兼容脚本沙箱中宿主 API 挂在顶层窗口的场景）。
+ */
+
+export function isTauriTavernHost_ACU(): boolean {
+  try {
+    return Boolean((globalThis as any).__TAURITAVERN__ || (globalThis as any).window?.__TAURITAVERN__);
+  } catch {
+    return false;
+  }
+}

--- a/tests/service/ai/api-call.test.ts
+++ b/tests/service/ai/api-call.test.ts
@@ -57,6 +57,7 @@ import {
   callAIWithPreset_ACU,
   callCustomOpenAI_ACU_Direct,
   buildCustomApiRequestBody_ACU,
+  normalizeSTNativeProxyBase_ACU,
 } from '../../../src/service/ai/api-call';
 
 beforeEach(() => {
@@ -273,6 +274,37 @@ describe('callCustomOpenAI_ACU_Direct', () => {
   });
 });
 
+// ═══ normalizeSTNativeProxyBase_ACU（原版 ST 原生协议源基址归一化） ═══
+describe('normalizeSTNativeProxyBase_ACU', () => {
+  it('claude：空路径补 /v1，已有 /v1 不重复，剥误贴的 /messages 尾段', () => {
+    expect(normalizeSTNativeProxyBase_ACU('https://api.anthropic.com', 'claude')).toBe('https://api.anthropic.com/v1');
+    expect(normalizeSTNativeProxyBase_ACU('https://api.anthropic.com/', 'claude')).toBe('https://api.anthropic.com/v1');
+    expect(normalizeSTNativeProxyBase_ACU('https://api.anthropic.com/v1', 'claude')).toBe('https://api.anthropic.com/v1');
+    expect(normalizeSTNativeProxyBase_ACU('https://api.anthropic.com/v1/messages', 'claude')).toBe('https://api.anthropic.com/v1');
+    expect(normalizeSTNativeProxyBase_ACU('https://api.anthropic.com/chat/completions', 'claude')).toBe('https://api.anthropic.com/v1');
+    // 自建代理子路径保留原样（用户有意为之），仅按 ST 拼接语义补 /v1
+    expect(normalizeSTNativeProxyBase_ACU('https://gw.example.com/claude', 'claude')).toBe('https://gw.example.com/claude/v1');
+  });
+
+  it('claude：/v1beta 误配纠正为 /v1（ST claude 源 fetch(apiUrl+/messages)）', () => {
+    expect(normalizeSTNativeProxyBase_ACU('https://api.anthropic.com/v1beta', 'claude')).toBe('https://api.anthropic.com/v1');
+  });
+
+  it('makersuite：剥 /v1beta 与 /v1 版本段（ST 服务端自补 apiVersion）', () => {
+    expect(normalizeSTNativeProxyBase_ACU('https://generativelanguage.googleapis.com', 'makersuite')).toBe('https://generativelanguage.googleapis.com');
+    expect(normalizeSTNativeProxyBase_ACU('https://generativelanguage.googleapis.com/', 'makersuite')).toBe('https://generativelanguage.googleapis.com');
+    expect(normalizeSTNativeProxyBase_ACU('https://generativelanguage.googleapis.com/v1beta', 'makersuite')).toBe('https://generativelanguage.googleapis.com');
+    expect(normalizeSTNativeProxyBase_ACU('https://generativelanguage.googleapis.com/v1', 'makersuite')).toBe('https://generativelanguage.googleapis.com');
+    expect(normalizeSTNativeProxyBase_ACU('https://gw.example.com/gemini/v1beta', 'makersuite')).toBe('https://gw.example.com/gemini');
+  });
+
+  it('空值与非法 URL 安全透传', () => {
+    expect(normalizeSTNativeProxyBase_ACU('', 'claude')).toBe('');
+    expect(normalizeSTNativeProxyBase_ACU(undefined, 'makersuite')).toBe('');
+    expect(normalizeSTNativeProxyBase_ACU('not-a-url/v1beta', 'makersuite')).toBe('not-a-url');
+  });
+});
+
 // ═══ buildCustomApiRequestBody_ACU ═══
 describe('buildCustomApiRequestBody_ACU', () => {
   it('custom_api_format 缺省回退 openai_compat，预设值白名单透传', () => {
@@ -309,23 +341,27 @@ describe('buildCustomApiRequestBody_ACU', () => {
     );
     expect(claudeBody.chat_completion_source).toBe('claude');
     expect(claudeBody.custom_api_format).toBeUndefined();
-    expect(claudeBody.reverse_proxy).toBe('https://api.anthropic.com');
+    // ST claude 源 fetch(apiUrl + '/messages')：基址自动补 /v1
+    expect(claudeBody.reverse_proxy).toBe('https://api.anthropic.com/v1');
     expect(claudeBody.proxy_password).toBe('sk-ant-test');
 
     const geminiBody = buildCustomApiRequestBody_ACU(
       [{ role: 'user', content: 'test' }],
-      { url: 'https://generativelanguage.googleapis.com', model: 'gemini-2.5-pro', apiKey: 'gk-test', customApiFormat: 'gemini_interactions' as any },
+      { url: 'https://generativelanguage.googleapis.com/v1beta', model: 'gemini-2.5-pro', apiKey: 'gk-test', customApiFormat: 'gemini_interactions' as any },
     );
     expect(geminiBody.chat_completion_source).toBe('makersuite');
+    // ST makersuite 源自补 /v1beta：基址自动剥版本段
+    expect(geminiBody.reverse_proxy).toBe('https://generativelanguage.googleapis.com');
     expect(geminiBody.proxy_password).toBe('gk-test');
 
-    // Responses 在 ST 无原生后端：回退 custom；openai_compat 恒 custom 且 proxy_password 留空
+    // Responses 在 ST 无原生后端：回退 custom；openai_compat 恒 custom 且 proxy_password 留空、url 原样
     const responsesBody = buildCustomApiRequestBody_ACU(
       [{ role: 'user', content: 'test' }],
       { url: 'https://api.openai.com/v1', model: 'gpt-4', apiKey: 'sk-test', customApiFormat: 'openai_responses' as any },
     );
     expect(responsesBody.chat_completion_source).toBe('custom');
     expect(responsesBody.proxy_password).toBe('');
+    expect(responsesBody.reverse_proxy).toBe('https://api.openai.com/v1');
 
     const compatBody = buildCustomApiRequestBody_ACU(
       [{ role: 'user', content: 'test' }],
@@ -333,6 +369,7 @@ describe('buildCustomApiRequestBody_ACU', () => {
     );
     expect(compatBody.chat_completion_source).toBe('custom');
     expect(compatBody.proxy_password).toBe('');
+    expect(compatBody.reverse_proxy).toBe('https://api.openai.com/v1');
   });
 
   it('max_tokens=0 不被回退为 20000', () => {

--- a/tests/service/ai/api-call.test.ts
+++ b/tests/service/ai/api-call.test.ts
@@ -275,6 +275,27 @@ describe('callCustomOpenAI_ACU_Direct', () => {
 
 // ═══ buildCustomApiRequestBody_ACU ═══
 describe('buildCustomApiRequestBody_ACU', () => {
+  it('custom_api_format 缺省回退 openai_compat，预设值白名单透传', () => {
+    const defaultBody = buildCustomApiRequestBody_ACU(
+      [{ role: 'user', content: 'test' }],
+      { url: 'https://api.example.com', model: 'gpt-4' },
+    );
+    expect(defaultBody.chat_completion_source).toBe('custom');
+    expect(defaultBody.custom_api_format).toBe('openai_compat');
+
+    const claudeBody = buildCustomApiRequestBody_ACU(
+      [{ role: 'user', content: 'test' }],
+      { url: 'https://api.example.com', model: 'gpt-4', customApiFormat: 'claude_messages' as any },
+    );
+    expect(claudeBody.custom_api_format).toBe('claude_messages');
+
+    const invalidBody = buildCustomApiRequestBody_ACU(
+      [{ role: 'user', content: 'test' }],
+      { url: 'https://api.example.com', model: 'gpt-4', customApiFormat: 'unknown_format' as any },
+    );
+    expect(invalidBody.custom_api_format).toBe('openai_compat');
+  });
+
   it('max_tokens=0 不被回退为 20000', () => {
     const body = buildCustomApiRequestBody_ACU(
       [{ role: 'user', content: 'test' }],

--- a/tests/service/ai/api-call.test.ts
+++ b/tests/service/ai/api-call.test.ts
@@ -276,24 +276,63 @@ describe('callCustomOpenAI_ACU_Direct', () => {
 // ═══ buildCustomApiRequestBody_ACU ═══
 describe('buildCustomApiRequestBody_ACU', () => {
   it('custom_api_format 缺省回退 openai_compat，预设值白名单透传', () => {
-    const defaultBody = buildCustomApiRequestBody_ACU(
-      [{ role: 'user', content: 'test' }],
-      { url: 'https://api.example.com', model: 'gpt-4' },
-    );
-    expect(defaultBody.chat_completion_source).toBe('custom');
-    expect(defaultBody.custom_api_format).toBe('openai_compat');
+    (globalThis as any).__TAURITAVERN__ = { version: 'test' };
+    try {
+      const defaultBody = buildCustomApiRequestBody_ACU(
+        [{ role: 'user', content: 'test' }],
+        { url: 'https://api.example.com', model: 'gpt-4' },
+      );
+      expect(defaultBody.chat_completion_source).toBe('custom');
+      expect(defaultBody.custom_api_format).toBe('openai_compat');
 
+      const claudeBody = buildCustomApiRequestBody_ACU(
+        [{ role: 'user', content: 'test' }],
+        { url: 'https://api.example.com', model: 'gpt-4', customApiFormat: 'claude_messages' as any },
+      );
+      expect(claudeBody.custom_api_format).toBe('claude_messages');
+      expect(claudeBody.chat_completion_source).toBe('custom');
+
+      const invalidBody = buildCustomApiRequestBody_ACU(
+        [{ role: 'user', content: 'test' }],
+        { url: 'https://api.example.com', model: 'gpt-4', customApiFormat: 'unknown_format' as any },
+      );
+      expect(invalidBody.custom_api_format).toBe('openai_compat');
+    } finally {
+      delete (globalThis as any).__TAURITAVERN__;
+    }
+  });
+
+  it('原版 ST 宿主：协议映射到原生 chat_completion_source，不带 custom_api_format', () => {
     const claudeBody = buildCustomApiRequestBody_ACU(
       [{ role: 'user', content: 'test' }],
-      { url: 'https://api.example.com', model: 'gpt-4', customApiFormat: 'claude_messages' as any },
+      { url: 'https://api.anthropic.com', model: 'claude-sonnet-4-5-20250929', apiKey: 'sk-ant-test', customApiFormat: 'claude_messages' as any },
     );
-    expect(claudeBody.custom_api_format).toBe('claude_messages');
+    expect(claudeBody.chat_completion_source).toBe('claude');
+    expect(claudeBody.custom_api_format).toBeUndefined();
+    expect(claudeBody.reverse_proxy).toBe('https://api.anthropic.com');
+    expect(claudeBody.proxy_password).toBe('sk-ant-test');
 
-    const invalidBody = buildCustomApiRequestBody_ACU(
+    const geminiBody = buildCustomApiRequestBody_ACU(
       [{ role: 'user', content: 'test' }],
-      { url: 'https://api.example.com', model: 'gpt-4', customApiFormat: 'unknown_format' as any },
+      { url: 'https://generativelanguage.googleapis.com', model: 'gemini-2.5-pro', apiKey: 'gk-test', customApiFormat: 'gemini_interactions' as any },
     );
-    expect(invalidBody.custom_api_format).toBe('openai_compat');
+    expect(geminiBody.chat_completion_source).toBe('makersuite');
+    expect(geminiBody.proxy_password).toBe('gk-test');
+
+    // Responses 在 ST 无原生后端：回退 custom；openai_compat 恒 custom 且 proxy_password 留空
+    const responsesBody = buildCustomApiRequestBody_ACU(
+      [{ role: 'user', content: 'test' }],
+      { url: 'https://api.openai.com/v1', model: 'gpt-4', apiKey: 'sk-test', customApiFormat: 'openai_responses' as any },
+    );
+    expect(responsesBody.chat_completion_source).toBe('custom');
+    expect(responsesBody.proxy_password).toBe('');
+
+    const compatBody = buildCustomApiRequestBody_ACU(
+      [{ role: 'user', content: 'test' }],
+      { url: 'https://api.openai.com/v1', model: 'gpt-4', apiKey: 'sk-test' },
+    );
+    expect(compatBody.chat_completion_source).toBe('custom');
+    expect(compatBody.proxy_password).toBe('');
   });
 
   it('max_tokens=0 不被回退为 20000', () => {

--- a/tests/service/ai/prompt-api-call.test.ts
+++ b/tests/service/ai/prompt-api-call.test.ts
@@ -231,6 +231,31 @@ describe('handleApiResponse_ACU', () => {
     expect(mockReader.releaseLock).toHaveBeenCalled();
   });
 
+  it('流式模式：Anthropic SSE（claude_messages）拼接 content_block_delta.text', async () => {
+    mockSettings.streamingEnabled = true;
+    const encoder = new TextEncoder();
+    const chunks = [
+      encoder.encode('data: {"type":"content_block_delta","delta":{"type":"text_delta","text":"你"}}\n\n'),
+      encoder.encode('data: {"type":"content_block_delta","delta":{"type":"text_delta","text":"好"}}\n\n'),
+      encoder.encode('data: {"type":"message_stop"}\n\n'),
+    ];
+    let chunkIndex = 0;
+    const mockReader = {
+      read: vi.fn(async () => {
+        if (chunkIndex < chunks.length) {
+          return { done: false, value: chunks[chunkIndex++] };
+        }
+        return { done: true, value: undefined };
+      }),
+      releaseLock: vi.fn(),
+    };
+    const mockResponse = {
+      body: { getReader: () => mockReader },
+    };
+    const result = await handleApiResponse_ACU(mockResponse);
+    expect(result).toBe('你好');
+  });
+
   it('非流式模式：响应带 usage 时经回调回传（含 cached_tokens）', async () => {
     mockSettings.streamingEnabled = false;
     const onUsage = vi.fn();

--- a/tests/service/ai/prompt-api-call.test.ts
+++ b/tests/service/ai/prompt-api-call.test.ts
@@ -256,6 +256,30 @@ describe('handleApiResponse_ACU', () => {
     expect(result).toBe('你好');
   });
 
+  it('流式模式：Gemini SSE（gemini_interactions）拼接 candidates parts text 并跳过 thought', async () => {
+    mockSettings.streamingEnabled = true;
+    const encoder = new TextEncoder();
+    const chunks = [
+      encoder.encode('data: {"candidates":[{"content":{"parts":[{"text":"你"}],"role":"model"}}]}\n\n'),
+      encoder.encode('data: {"candidates":[{"content":{"parts":[{"text":"思考中","thought":true},{"text":"好"}],"role":"model"}}]}\n\n'),
+    ];
+    let chunkIndex = 0;
+    const mockReader = {
+      read: vi.fn(async () => {
+        if (chunkIndex < chunks.length) {
+          return { done: false, value: chunks[chunkIndex++] };
+        }
+        return { done: true, value: undefined };
+      }),
+      releaseLock: vi.fn(),
+    };
+    const mockResponse = {
+      body: { getReader: () => mockReader },
+    };
+    const result = await handleApiResponse_ACU(mockResponse);
+    expect(result).toBe('你好');
+  });
+
   it('非流式模式：响应带 usage 时经回调回传（含 cached_tokens）', async () => {
     mockSettings.streamingEnabled = false;
     const onUsage = vi.fn();


### PR DESCRIPTION
## 背景

TauriTavern 主 API 提供了四个「自定义」渠道，各自对应不同的上游端点与请求/响应变形。本 PR **参照这一设计**给 API 预设增加「接口协议」四选一，并做了**双宿主适配**，保证 TT 与原版 SillyTavern 用户都能使用：

| 选项 | TT（Rust 后端） | 原版 ST（Node 后端） |
|---|---|---|
| 兼容 OpenAI（默认） | `custom_api_format: openai_compat` → `/chat/completions` | `chat_completion_source: custom`（现状行为，零变化） |
| 兼容 OpenAI Responses | → `/responses` | ST 无对应后端，回退 custom（`/chat/completions`） |
| 兼容 Claude Messages | → `/messages` | 映射 `chat_completion_source: claude`——ST 服务端自带 Anthropic 变形（`fetch(apiUrl + '/messages')`），流式原样透传 Anthropic SSE |
| 兼容 Gemini Interactions | → `/interactions` | 映射 `chat_completion_source: makersuite`——ST 服务端自带 Gemini 变形（自补 `/v1beta`），流式透传 Gemini SSE |

## 改动

**预设与归一化**
- `src/service/settings/api-preset-service.ts`：新增 `CustomApiFormat_ACU` 类型 + `normalizeCustomApiFormat_ACU` 白名单归一化（非法值回退 `openai_compat`）；`ApiPresetApiConfig_ACU` 增加 `customApiFormat` 字段并纳入 normalize 白名单
- `src/presentation-v2/composables/useApiPresetManagement.ts`：草稿三映射（空预设默认 `openai_compat` / 预设→草稿 / 草稿→预设白名单校验）
- `src/presentation-v2/components/ApiConfigPanel.vue`：自定义连接方式下新增「接口协议」下拉（置于端点上方），hint 说明两种宿主的行为差异与「纯原生端点下加载模型可能失败，可手填模型名」提示

**请求体按宿主分流**
- `src/shared/host-detect.ts`（新增）：`isTauriTavernHost_ACU()` 运行时检测 `window.__TAURITAVERN__`
- `src/service/ai/api-call.ts`：`buildCustomApiRequestBody_ACU` 中——TT 下透传 `custom_api_format`（消费点二次白名单兜底）；原版 ST 下把 claude/gemini 映射为 `chat_completion_source: 'claude'/'makersuite'`，预设密钥经 `proxy_password` 透传（ST 原生源对 reverse_proxy 模式的既有支持），`openai_compat`/`openai_responses` 维持 `custom`
- **ST 原生源基址归一化**（`normalizeSTNativeProxyBase_ACU`）：对齐 ST 自身的 URL 拼接语义——claude 源 `fetch(apiUrl + '/messages')` 要求基址含 `/v1`（与 ST 官方常量 `API_CLAUDE = https://api.anthropic.com/v1` 一致），空路径自动补 `/v1`；makersuite 源服务端自补 `${apiVersion}/models/...`，基址带 `/v1beta`、`/v1` 时自动剥除；用户误贴的 `/messages`、`/chat/completions`、`/responses`、`/interactions` 尾段一并纠正。用户自建代理子路径（如 `https://gw.example.com/claude`）保留不改写

**响应解析**
- `src/service/ai/prompt-builder/prompt-api-call.ts`：流式解析新增 Anthropic SSE 分支（`content_block_delta`/`text_delta`）与 Gemini SSE 分支（`candidates[].content.parts[].text`，跳过 thought 段）；两种原生的非流式回包 ST 服务端已归一为 OpenAI 形态，无需改动

**测试**
- `api-call.test.ts`：TT 契约用例（缺省回退/白名单透传/ST 下不带 `custom_api_format`）+ ST 映射用例（claude/makersuite 源、`/v1` 补齐与版本段剥除、Responses 回退）+ `normalizeSTNativeProxyBase_ACU` 单元用例（claude/makersuite/边界 12 断言）
- `prompt-api-call.test.ts`：Anthropic SSE 与 Gemini SSE 拼接用例

## 兼容性

默认值与现有行为完全一致（`openai_compat` + `chat_completion_source: 'custom'`），存量预设经 normalize 自动补齐字段，无破坏性变更。原版 ST 用户选择 Claude/Gemini 协议时端点直接填服务商地址即可（插件按 ST 拼接语义自动归一），密钥取预设内配置、无需在 ST 连接设置里另配。

## 验证

- `tsc --noEmit` 0 错误
- vitest 全量 **7358 通过 / 28 skipped（344 文件）**，含新增用例；仅 `tests/presentation/bootstrap/init.test.ts` 5 例失败——在干净 main@e6f8ef3 上同样失败（9.1 自带，与本 PR 无关）
- `npm run build` 通过

注：未包含 `index.js` / `dist` 打包产物——在 main@8f32617 上不带任何改动直接重建即产生约 1200 行与源码无关的空白漂移（疑似构建脚本/环境差异），为避免污染 diff 请合并后由 release 流程重新打包。