### PR TITLE
API预设页面，支持选择提示词后处理

### DIFF
--- a/src/presentation-v2/components/ApiConfigPanel.vue
+++ b/src/presentation-v2/components/ApiConfigPanel.vue
@@ -149,6 +149,17 @@
             placeholder="top_p, reasoning_effort"
           />
         </AcuFormRow>
+        <AcuFormRow
+          label="提示词后处理"
+          hint="SillyTavern custom_prompt_post_processing，默认严格（与旧版本行为一致）。未选择=不带该字段原样透传消息，可保留提示词组中 system 段的角色；严格等模式会把提示词中部的 system 消息强制改为 user。"
+        >
+          <AcuSelect
+            :options="promptPostProcessingOptions"
+            :model-value="activeDraft.promptPostProcessing"
+            placeholder="未选择"
+            @update:model-value="setPromptPostProcessing"
+          />
+        </AcuFormRow>
         <AcuFormRow label="附加请求标头" hint="每行一个 Header: Value，追加到请求头中。">
           <AcuTextarea
             v-model="activeDraft.requestHeaders"
@@ -193,6 +204,7 @@ import {
   type ApiPresetDraft,
   type ConnectionMode,
 } from "../composables/useApiPresetManagement";
+import type { ApiPromptPostProcessingValue_ACU } from "../../service/settings/api-preset-service";
 import { useUiCloseGuard } from "../composables/useUiCloseGuard";
 import { apiCopy } from "../copy/api-copy";
 import {
@@ -239,6 +251,33 @@ const connectionModeOptions: AcuSegmentedOption[] = [
   { value: "main", label: "酒馆主 API" },
   { value: "custom", label: "自定义" },
   { value: "tavern", label: "酒馆预设" },
+];
+// 选项与 SillyTavern「提示词后处理」下拉一致；'' 为「未选择」，默认 'strict'。
+const promptPostProcessingOptions: AcuSelectOption[] = [
+  { value: "", label: "未选择" },
+  {
+    value: "merge_tools",
+    label: "合并相同角色连续的发言（含工具）",
+    group: "With Tools",
+  },
+  {
+    value: "semi_tools",
+    label: "半严格（强制对话角色交替）（含工具）",
+    group: "With Tools",
+  },
+  {
+    value: "strict_tools",
+    label: "严格（强制对话角色交替、用户最先）（含工具）",
+    group: "With Tools",
+  },
+  { value: "merge", label: "合并相同角色连续的发言", group: "No Tools" },
+  { value: "semi", label: "半严格（强制对话角色交替）", group: "No Tools" },
+  {
+    value: "strict",
+    label: "严格（强制对话角色交替、用户最先）",
+    group: "No Tools",
+  },
+  { value: "single", label: "单一用户消息（无工具）" },
 ];
 const modelSelectOptions = computed<AcuSelectOption[]>(() =>
   store.modelOptions.map((m) => ({ value: m, label: m })),
@@ -369,6 +408,12 @@ function saveActiveDraft(): void {
 
 function setActiveConnectionMode(value: string): void {
   applyConnectionMode(activeDraft, value as ConnectionMode);
+  activeDraftSavedAt.value = null;
+}
+
+function setPromptPostProcessing(value: string): void {
+  activeDraft.promptPostProcessing =
+    value as ApiPromptPostProcessingValue_ACU;
   activeDraftSavedAt.value = null;
 }
 

--- a/src/presentation-v2/components/_lib/AcuSelect.vue
+++ b/src/presentation-v2/components/_lib/AcuSelect.vue
@@ -5,15 +5,16 @@
       <i class="fa-solid fa-chevron-down acu-select__caret" :class="{ 'acu-select__caret--open': open }"></i>
     </button>
     <ul v-if="open" class="acu-select__menu">
-      <li
-        v-for="opt in options"
-        :key="opt.value"
-        class="acu-select__item"
-        :class="{ 'acu-select__item--active': opt.value === modelValue }"
-        @click="select(opt.value)"
-      >
-        {{ opt.label }}
-      </li>
+      <template v-for="entry in groupedOptions" :key="entry.key">
+        <li v-if="entry.group !== null" class="acu-select__group">{{ entry.group }}</li>
+        <li
+          class="acu-select__item"
+          :class="{ 'acu-select__item--active': entry.opt.value === modelValue }"
+          @click="select(entry.opt.value)"
+        >
+          {{ entry.opt.label }}
+        </li>
+      </template>
       <li v-if="!options.length" class="acu-select__empty">无可选项</li>
     </ul>
   </div>
@@ -26,6 +27,8 @@ import { getAcuHostDocument } from '../../bootstrap/host-document';
 export interface AcuSelectOption {
   value: string;
   label: string;
+  /** 可选分组名：相邻同名分组的选项会共享一个组标题（不可点击，仅视觉分组）。 */
+  group?: string;
 }
 
 const props = withDefaults(defineProps<{
@@ -57,6 +60,21 @@ const hasSelection = computed(() => props.options.some(o => o.value === props.mo
 const selectedLabel = computed(() => {
   const item = props.options.find(o => o.value === props.modelValue);
   return item ? item.label : props.placeholder;
+});
+
+const groupedOptions = computed(() => {
+  const groupOf = (opt: AcuSelectOption): string | null =>
+    typeof opt.group === 'string' && opt.group ? opt.group : null;
+  return props.options.map((opt, index) => {
+    const group = groupOf(opt);
+    const prevGroup = index > 0 ? groupOf(props.options[index - 1]) : null;
+    return {
+      key: `${index}:${opt.value}`,
+      opt,
+      group,
+      showGroupLabel: group !== null && group !== prevGroup,
+    };
+  });
 });
 
 function select(value: string) {
@@ -130,6 +148,16 @@ onBeforeUnmount(() => {
   border-radius: var(--acu-radius-sm); box-shadow: var(--acu-shadow);
   min-width: 0; max-width: 100%; box-sizing: border-box;
   max-height: var(--acu-menu-max-height, 240px); overflow-y: auto;
+}
+
+.acu-select__group {
+  padding: var(--acu-space-2, 8px) var(--acu-space-3, 12px) var(--acu-space-1, 4px);
+  font-size: var(--acu-font-size-micro, 10px);
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  color: var(--acu-text-3);
+  user-select: none;
+  pointer-events: none;
 }
 
 .acu-select__item {

--- a/src/presentation-v2/composables/useApiPresetManagement.ts
+++ b/src/presentation-v2/composables/useApiPresetManagement.ts
@@ -1,3 +1,4 @@
+import type { ApiPromptPostProcessingValue_ACU } from '../../service/settings/api-preset-service';
 import type { AcuV2ApiMode, AcuV2ApiPreset } from '../stores/api-preset-store';
 
 export interface ApiPresetDraft {
@@ -13,6 +14,7 @@ export interface ApiPresetDraft {
   bodyParams: string;
   excludeBodyParams: string;
   requestHeaders: string;
+  promptPostProcessing: ApiPromptPostProcessingValue_ACU;
 }
 
 /** Effective connection mode — flattens apiMode + useMainApi into 3 user-visible states. */
@@ -50,6 +52,7 @@ export function createEmptyApiPresetDraft(): ApiPresetDraft {
     bodyParams: '',
     excludeBodyParams: '',
     requestHeaders: '',
+    promptPostProcessing: 'strict',
   };
 }
 
@@ -67,6 +70,7 @@ export function apiPresetDraftFromPreset(preset: AcuV2ApiPreset): ApiPresetDraft
     bodyParams: preset.apiConfig.bodyParams || '',
     excludeBodyParams: preset.apiConfig.excludeBodyParams || '',
     requestHeaders: preset.apiConfig.requestHeaders || '',
+    promptPostProcessing: preset.apiConfig.promptPostProcessing || '',
   };
 }
 
@@ -85,6 +89,7 @@ export function apiPresetFromDraft(draft: ApiPresetDraft): AcuV2ApiPreset {
       bodyParams: draft.bodyParams || '',
       excludeBodyParams: draft.excludeBodyParams || '',
       requestHeaders: draft.requestHeaders || '',
+      promptPostProcessing: draft.promptPostProcessing || '',
     },
   };
 }

--- a/src/presentation-v2/stores/api-preset-store.ts
+++ b/src/presentation-v2/stores/api-preset-store.ts
@@ -78,7 +78,8 @@ function findPresetMatchingCurrentConfig(presets: AcuV2ApiPreset[]): AcuV2ApiPre
       preset.apiConfig.temperature === current.apiConfig.temperature &&
       preset.apiConfig.bodyParams === current.apiConfig.bodyParams &&
       preset.apiConfig.excludeBodyParams === current.apiConfig.excludeBodyParams &&
-      preset.apiConfig.requestHeaders === current.apiConfig.requestHeaders
+      preset.apiConfig.requestHeaders === current.apiConfig.requestHeaders &&
+      preset.apiConfig.promptPostProcessing === current.apiConfig.promptPostProcessing
     );
   }) ?? null;
 }

--- a/src/service/ai/api-call.ts
+++ b/src/service/ai/api-call.ts
@@ -6,7 +6,7 @@ export type { AiUsageMetadata_ACU };
 import { settings_ACU } from '../runtime/state-manager';
 import { isGenerateRawAvailable_ACU, generateRaw_ACU, sendConnectionManagerRequest_ACU, getHostRequestHeaders_ACU, getConnectionManagerProfiles_ACU, triggerSlash_ACU } from '../../data/gateways/ai-gateway';
 import { logDebug_ACU, logWarn_ACU } from '../../shared/utils';
-import { resolveApiConfigByPreset_ACU, type ApiPresetApiConfig_ACU, type ApiPresetApiMode_ACU } from '../settings/api-preset-service';
+import { resolveApiConfigByPreset_ACU, normalizePromptPostProcessing_ACU, type ApiPresetApiConfig_ACU, type ApiPresetApiMode_ACU } from '../settings/api-preset-service';
 
 function normalizeExcludeBodyParamsForSillyTavern_ACU(raw: any): string {
   if (typeof raw !== 'string') return '';
@@ -81,6 +81,15 @@ export function buildCustomApiRequestBody_ACU(
     ? [userBodyParams.trim(), ...extraIncludeLines].filter(Boolean).join('\n')
     : userBodyParams;
 
+  // 提示词后处理（custom_prompt_post_processing）改为 API 预设可配置。
+  // 背景：此前写死 'strict'，酒馆后端会把提示词中部的 system 消息强制改成 user
+  // （prompt-converters.js mergeMessages strict 模式），导致剧情推进等自定义
+  // 提示词组里用户指定的 SYSTEM 段在发送时丢失角色。
+  // 现在：默认 'strict'（与历史行为兼容）；预设选择具体值则透传；
+  // 显式选择「未选择」（''）时不携带该字段，后端原样透传消息，
+  // 完整保留用户配置的 system/user/assistant 结构。
+  const promptPostProcessing = normalizePromptPostProcessing_ACU(effectiveApiConfig?.promptPostProcessing);
+
   const body: Record<string, any> = {
     // 统一将 messages 的 role 归一为小写（system / user / assistant）。
     //
@@ -115,7 +124,6 @@ export function buildCustomApiRequestBody_ACU(
     reasoning_effort: 'medium',
     enable_web_search: false,
     request_images: false,
-    custom_prompt_post_processing: 'strict',
     reverse_proxy: effectiveApiConfig.url,
     proxy_password: '',
     custom_url: effectiveApiConfig.url,
@@ -123,6 +131,10 @@ export function buildCustomApiRequestBody_ACU(
     custom_include_body: includeBody,
     custom_exclude_body: normalizeExcludeBodyParamsForSillyTavern_ACU(effectiveApiConfig.excludeBodyParams),
   };
+  if (promptPostProcessing) {
+    // 「未选择」（''）时省略该键，酒馆后端（getPromptPostProcessing）按 none 处理，原样透传消息。
+    body.custom_prompt_post_processing = promptPostProcessing;
+  }
 
   return body;
 }

--- a/src/service/runtime/state-manager.ts
+++ b/src/service/runtime/state-manager.ts
@@ -209,7 +209,7 @@ export let currentJsonTableData_ACU: any = null;
 export let independentTableStates_ACU: any = {};
 
 export let settings_ACU: any = {
-    apiConfig: { url: '', apiKey: '', model: '', useMainApi: true, max_tokens: 60000, temperature: 1.0 },
+    apiConfig: { url: '', apiKey: '', model: '', useMainApi: true, max_tokens: 60000, temperature: 1.0, promptPostProcessing: 'strict' },
     apiMode: 'custom',
     streamingEnabled: false,
     tavernProfile: '',

--- a/src/service/settings/api-preset-service.ts
+++ b/src/service/settings/api-preset-service.ts
@@ -14,6 +14,44 @@ import { logWarn_ACU } from '../../shared/utils';
 
 export type ApiPresetApiMode_ACU = 'custom' | 'tavern';
 
+/**
+ * 提示词后处理（SillyTavern custom_prompt_post_processing）可选值。
+ * '' = 未选择：请求体不带该字段，酒馆后端原样透传消息（保留中部的 system 角色）。
+ * 缺失/非法值统一归一为 'strict'（默认严格，与历史写死 strict 的行为保持兼容）。
+ */
+export type ApiPromptPostProcessingValue_ACU =
+  | ''
+  | 'merge'
+  | 'semi'
+  | 'strict'
+  | 'single'
+  | 'merge_tools'
+  | 'semi_tools'
+  | 'strict_tools';
+
+export const API_PROMPT_POST_PROCESSING_VALUES_ACU: readonly ApiPromptPostProcessingValue_ACU[] = [
+  '',
+  'merge',
+  'semi',
+  'strict',
+  'single',
+  'merge_tools',
+  'semi_tools',
+  'strict_tools',
+];
+
+export const API_PROMPT_POST_PROCESSING_DEFAULT_ACU: ApiPromptPostProcessingValue_ACU = 'strict';
+
+export function normalizePromptPostProcessing_ACU(value: unknown): ApiPromptPostProcessingValue_ACU {
+  // 显式空串 = 用户选择「未选择」，保留；缺失/非字符串/非法值 → 默认严格。
+  if (typeof value !== 'string') return API_PROMPT_POST_PROCESSING_DEFAULT_ACU;
+  const normalized = value.trim();
+  if (normalized === '') return '';
+  return (API_PROMPT_POST_PROCESSING_VALUES_ACU as readonly string[]).includes(normalized)
+    ? (normalized as ApiPromptPostProcessingValue_ACU)
+    : API_PROMPT_POST_PROCESSING_DEFAULT_ACU;
+}
+
 export interface ApiPresetApiConfig_ACU {
   url: string;
   apiKey: string;
@@ -25,6 +63,7 @@ export interface ApiPresetApiConfig_ACU {
   bodyParams: string;
   excludeBodyParams: string;
   requestHeaders: string;
+  promptPostProcessing: ApiPromptPostProcessingValue_ACU;
 }
 
 export interface ApiPreset_ACU {
@@ -72,9 +111,10 @@ export function normalizeApiConfig_ACU(value: any): ApiPresetApiConfig_ACU {
     bodyParams: typeof source.bodyParams === 'string' ? source.bodyParams : '',
     excludeBodyParams: typeof source.excludeBodyParams === 'string' ? source.excludeBodyParams : '',
     requestHeaders: typeof source.requestHeaders === 'string' ? source.requestHeaders : '',
+    promptPostProcessing: normalizePromptPostProcessing_ACU(source.promptPostProcessing),
     ...Object.fromEntries(
       Object.entries(source).filter(([key]) =>
-        !['url', 'apiKey', 'model', 'useMainApi', 'max_tokens', 'maxTokens', 'temperature', 'bodyParams', 'excludeBodyParams', 'requestHeaders'].includes(key)
+        !['url', 'apiKey', 'model', 'useMainApi', 'max_tokens', 'maxTokens', 'temperature', 'bodyParams', 'excludeBodyParams', 'requestHeaders', 'promptPostProcessing'].includes(key)
       )
     ),
   };

--- a/src/service/settings/settings-service.ts
+++ b/src/service/settings/settings-service.ts
@@ -822,7 +822,7 @@ function forceDefaultTemplateAssistantPromptOnce_ACU() {
 
 export   function buildDefaultSettings_ACU() {
       return {
-          apiConfig: { url: '', apiKey: '', model: '', useMainApi: true, max_tokens: 60000, temperature: 1.0 },
+          apiConfig: { url: '', apiKey: '', model: '', useMainApi: true, max_tokens: 60000, temperature: 1.0, promptPostProcessing: 'strict' },
           apiMode: 'custom',
           tavernProfile: '',
           streamingEnabled: false, // [新增] 流式传输开关（默认关闭）

--- a/tests/service/ai/api-call.test.ts
+++ b/tests/service/ai/api-call.test.ts
@@ -466,6 +466,49 @@ describe('buildCustomApiRequestBody_ACU', () => {
     expect(body.messages[0]).not.toBe(original[0]);
   });
 
+  it('缺失 promptPostProcessing 时默认 strict（向后兼容旧版写死 strict 的行为）', () => {
+    const body = buildCustomApiRequestBody_ACU(
+      [{ role: 'system', content: '中部 system' }, { role: 'user', content: 'test' }],
+      { url: 'https://api.example.com', model: 'gpt-4' },
+    );
+    expect(body.custom_prompt_post_processing).toBe('strict');
+  });
+
+  it('显式选择未选择（空串）时不携带 custom_prompt_post_processing（后端原样透传消息）', () => {
+    // 未选择 = 不带该字段，酒馆后端按 none 处理，保留提示词组中 system 段的角色。
+    const body = buildCustomApiRequestBody_ACU(
+      [{ role: 'system', content: '中部 system' }, { role: 'user', content: 'test' }],
+      { url: 'https://api.example.com', model: 'gpt-4', promptPostProcessing: '' },
+    );
+    expect(body).not.toHaveProperty('custom_prompt_post_processing');
+  });
+
+  it('promptPostProcessing=merge 透传为 custom_prompt_post_processing', () => {
+    const body = buildCustomApiRequestBody_ACU(
+      [{ role: 'user', content: 'test' }],
+      { url: 'https://api.example.com', model: 'gpt-4', promptPostProcessing: 'merge' },
+    );
+    expect(body.custom_prompt_post_processing).toBe('merge');
+  });
+
+  it('promptPostProcessing=strict 等合法值原样透传', () => {
+    for (const value of ['semi', 'strict', 'single', 'merge_tools', 'semi_tools', 'strict_tools']) {
+      const body = buildCustomApiRequestBody_ACU(
+        [{ role: 'user', content: 'test' }],
+        { url: 'https://api.example.com', model: 'gpt-4', promptPostProcessing: value },
+      );
+      expect(body.custom_prompt_post_processing).toBe(value);
+    }
+  });
+
+  it('promptPostProcessing 非法值默认 strict', () => {
+    const body = buildCustomApiRequestBody_ACU(
+      [{ role: 'user', content: 'test' }],
+      { url: 'https://api.example.com', model: 'gpt-4', promptPostProcessing: 'fake-mode' },
+    );
+    expect(body.custom_prompt_post_processing).toBe('strict');
+  });
+
   it('缺失或非字符串 role、数组/原始值等异常消息原样保留，不静默改造成 undefined', () => {
     const input = [
       { content: '缺 role' },


### PR DESCRIPTION
- 酒馆自身的代码，让用户在提示词后处理为严格时，会把提示词中间的system角色自动降级为user
- 数据库之前API的提示词后处理默认都是严格（strict）
- API页面新增「提示词后处理」下拉框，选项与酒馆一致（未选择/含工具三档/ 无工具三档/单一用户消息）