### PR TITLE
fix(vector): 交火纪要索引改写跟随自定义列配置

### DIFF
--- a/src/service/vector/summary-vector-index-archive-service.ts
+++ b/src/service/vector/summary-vector-index-archive-service.ts
@@ -120,7 +120,12 @@ export interface SummaryVectorArchivePreparedRow_ACU {
  */
 export const SUMMARY_VECTOR_SOURCE_TEXT_MAX_CHARS_ACU = 1600;
 
-const SUMMARY_CHRONICLE_COLUMN_ALIASES_ACU = ['纪要', '纪要内容', '纪要正文', '事件纪要', '详细纪要', '正文'];
+export const SUMMARY_CHRONICLE_COLUMN_ALIASES_ACU = ['纪要', '纪要内容', '纪要正文', '事件纪要', '详细纪要', '正文'];
+
+export const SUMMARY_TIME_SPAN_COLUMN_ALIASES_ACU = ['时间跨度', '时间', '阶段', '时段'];
+export const SUMMARY_LOCATION_COLUMN_ALIASES_ACU = ['地点', '位置', '场景', '场所'];
+export const SUMMARY_SUMMARY_COLUMN_ALIASES_ACU = ['概要', '概览', '概述', '摘要'];
+export const SUMMARY_INDEX_CODE_COLUMN_ALIASES_ACU = ['编码索引'];
 
 /**
  * 概览在前保住高密度摘要信号，纪要正文补充实体与细节；两者都为空的行由调用方跳过。
@@ -327,7 +332,7 @@ function normalizeText_ACU(value: any): string {
     return String(value ?? '').trim();
 }
 
-function resolveColumnIndexByAliases_ACU(headerRow: any[], aliases: string[], fallbackIndex = -1): number {
+export function resolveColumnIndexByAliases_ACU(headerRow: any[], aliases: string[], fallbackIndex = -1): number {
     const normalizedAliases = aliases.map((item) => normalizeText_ACU(item).replace(/\s+/g, ''));
     const index = (Array.isArray(headerRow) ? headerRow : []).findIndex((header) => normalizedAliases.includes(normalizeText_ACU(header).replace(/\s+/g, '')));
     return index >= 0 ? index : fallbackIndex;
@@ -409,10 +414,10 @@ export function buildPreparedRows_ACU(table: any, summaryKey: string): {
 } {
     const content = Array.isArray(table?.content) ? table.content : [];
     const headerRow = Array.isArray(content[0]) ? content[0] : [];
-    const timeSpanColIdx = resolveColumnIndexByAliases_ACU(headerRow, ['时间跨度', '时间', '阶段', '时段'], 0);
-    const locationColIdx = resolveColumnIndexByAliases_ACU(headerRow, ['地点', '位置', '场景', '场所'], 1);
-    const summaryColIdx = resolveColumnIndexByAliases_ACU(headerRow, ['概要', '概览', '概述', '摘要']);
-    const indexColIdx = resolveColumnIndexByAliases_ACU(headerRow, ['编码索引']);
+    const timeSpanColIdx = resolveColumnIndexByAliases_ACU(headerRow, SUMMARY_TIME_SPAN_COLUMN_ALIASES_ACU, 0);
+    const locationColIdx = resolveColumnIndexByAliases_ACU(headerRow, SUMMARY_LOCATION_COLUMN_ALIASES_ACU, 1);
+    const summaryColIdx = resolveColumnIndexByAliases_ACU(headerRow, SUMMARY_SUMMARY_COLUMN_ALIASES_ACU);
+    const indexColIdx = resolveColumnIndexByAliases_ACU(headerRow, SUMMARY_INDEX_CODE_COLUMN_ALIASES_ACU);
     const chronicleColIdx = resolveColumnIndexByAliases_ACU(headerRow, SUMMARY_CHRONICLE_COLUMN_ALIASES_ACU);
     if (summaryColIdx < 0) {
         return { rows: [], skippedRowCount: 0, error: '纪要表缺少概要列，无法构建纪要向量索引。' };

--- a/src/service/vector/summary-vector-index-runtime.ts
+++ b/src/service/vector/summary-vector-index-runtime.ts
@@ -48,6 +48,12 @@ import {
 import {
     buildPreparedRows_ACU,
     findSummaryTable_ACU,
+    resolveColumnIndexByAliases_ACU,
+    SUMMARY_CHRONICLE_COLUMN_ALIASES_ACU,
+    SUMMARY_INDEX_CODE_COLUMN_ALIASES_ACU,
+    SUMMARY_LOCATION_COLUMN_ALIASES_ACU,
+    SUMMARY_SUMMARY_COLUMN_ALIASES_ACU,
+    SUMMARY_TIME_SPAN_COLUMN_ALIASES_ACU,
     type SummaryVectorArchivePreparedRow_ACU,
 } from './summary-vector-index-archive-service';
 
@@ -324,12 +330,7 @@ function escapeMarkdownTableCell_ACU(value: any): string {
         .replace(/\|/g, '\\|');
 }
 
-function buildSummaryIndexOverwriteContent_ACU(candidates: SummaryIndexSelectedCandidate_ACU[]): string {
-    const selectedRows = (Array.isArray(candidates) ? candidates : [])
-        .map((candidate) => candidate.row)
-        .filter((row): row is ChatSummaryVectorIndexRow_ACU => !!row)
-        .sort((left, right) => (Number(left.rowOrder) || 0) - (Number(right.rowOrder) || 0));
-
+function buildFallbackSummaryIndexOverwriteContent_ACU(selectedRows: ChatSummaryVectorIndexRow_ACU[]): string {
     const lines = [
         '# 纪要索引',
         '',
@@ -346,6 +347,92 @@ function buildSummaryIndexOverwriteContent_ACU(candidates: SummaryIndexSelectedC
     }
 
     return lines.join('\n');
+}
+
+function resolveCrossfireExtraIndexColumns_ACU(): { columns: string[]; colIndexes: number[]; headerRow: any[]; table: any; template: string } | null {
+    try {
+        const selected = findSummaryTable_ACU();
+        const table = selected?.table;
+        const cfg = table?.exportConfig;
+        if (!table || !cfg || cfg.extraIndexEnabled !== true) return null;
+        const content = Array.isArray(table.content) ? table.content : [];
+        const headerRow = Array.isArray(content[0]) ? content[0] : [];
+        if (headerRow.length === 0) return null;
+        const selectedRaw = Array.isArray(cfg.extraIndexColumns) ? cfg.extraIndexColumns : [];
+        const columns: string[] = [];
+        for (const col of selectedRaw) {
+            if (typeof col === 'string' && headerRow.includes(col) && !columns.includes(col)) columns.push(col);
+        }
+        if (columns.length === 0) return null;
+        const colIndexes = columns.map((col) => headerRow.indexOf(col)).filter((idx) => idx >= 0);
+        if (colIndexes.length === 0) return null;
+        const template = typeof cfg.extraIndexInjectionTemplate === 'string' ? cfg.extraIndexInjectionTemplate : '';
+        return { columns, colIndexes, headerRow, table, template };
+    } catch (_error) {
+        return null;
+    }
+}
+
+function getStoredRowFallbackCell_ACU(row: ChatSummaryVectorIndexRow_ACU, columnName: string): string {
+    const name = String(columnName || '').trim();
+    if (SUMMARY_TIME_SPAN_COLUMN_ALIASES_ACU.includes(name)) return (row as any)?.timeSpan ?? '';
+    if (SUMMARY_LOCATION_COLUMN_ALIASES_ACU.includes(name)) return (row as any)?.location ?? '';
+    if (SUMMARY_SUMMARY_COLUMN_ALIASES_ACU.includes(name)) return (row as any)?.summary ?? '';
+    if (SUMMARY_INDEX_CODE_COLUMN_ALIASES_ACU.includes(name)) return (row as any)?.indexCode ?? '';
+    if (SUMMARY_CHRONICLE_COLUMN_ALIASES_ACU.includes(name)) return (row as any)?.vectorSourceText ?? '';
+    return '';
+}
+
+function buildSummaryIndexOverwriteContent_ACU(candidates: SummaryIndexSelectedCandidate_ACU[]): string {
+    const selectedRows = (Array.isArray(candidates) ? candidates : [])
+        .map((candidate) => candidate.row)
+        .filter((row): row is ChatSummaryVectorIndexRow_ACU => !!row)
+        .sort((left, right) => (Number(left.rowOrder) || 0) - (Number(right.rowOrder) || 0));
+
+    try {
+        const spec = resolveCrossfireExtraIndexColumns_ACU();
+        if (spec) {
+            const content = Array.isArray(spec.table?.content) ? spec.table.content : [];
+            const dataRows = content.slice(1).filter((row: any) => Array.isArray(row));
+            const indexCodeColIdx = resolveColumnIndexByAliases_ACU(spec.headerRow, SUMMARY_INDEX_CODE_COLUMN_ALIASES_ACU);
+            const byIndexCode = new Map<string, any[]>();
+            dataRows.forEach((row: any[]) => {
+                const indexCode = indexCodeColIdx >= 0 ? normalizeText_ACU(row?.[indexCodeColIdx]) : '';
+                if (indexCode && !byIndexCode.has(indexCode)) byIndexCode.set(indexCode, row);
+            });
+            const lines = [
+                `| ${spec.columns.join(' | ')} |`,
+                `|${spec.columns.map(() => '---').join('|')}|`,
+            ];
+            selectedRows.forEach((row) => {
+                const liveRow = byIndexCode.get(normalizeText_ACU((row as any)?.indexCode)) || null;
+                const cells = spec.colIndexes.map((colIdx, i) => {
+                    let value = '';
+                    if (liveRow) {
+                        const v = liveRow[colIdx];
+                        value = v === null || v === undefined ? '' : String(v);
+                    } else {
+                        value = getStoredRowFallbackCell_ACU(row, spec.columns[i]);
+                    }
+                    return escapeMarkdownTableCell_ACU(value);
+                });
+                lines.push(`| ${cells.join(' | ')} |`);
+            });
+            if (selectedRows.length === 0) {
+                const markerCol = spec.columns.findIndex((col) => SUMMARY_SUMMARY_COLUMN_ALIASES_ACU.includes(String(col).trim()));
+                const markerIdx = markerCol >= 0 ? markerCol : 0;
+                lines.push(`| ${spec.columns.map((_, i) => (i === markerIdx ? '（无命中纪要）' : '')).join(' | ')} |`);
+            }
+            const tableText = lines.join('\n');
+            if (spec.template && spec.template.includes('$1')) {
+                return spec.template.replace('$1', tableText);
+            }
+            return `# 纪要索引\n\n${tableText}`;
+        }
+    } catch (error) {
+        logWarn_ACU('[交火模式纪要索引] 自定义列拼表失败，回退固定4列:', error);
+    }
+    return buildFallbackSummaryIndexOverwriteContent_ACU(selectedRows);
 }
 
 async function upsertOriginalSummaryIndexEntry_ACU(content: string): Promise<void> {

--- a/tests/service/vector/summary-vector-index-runtime.test.ts
+++ b/tests/service/vector/summary-vector-index-runtime.test.ts
@@ -95,6 +95,16 @@ vi.mock('../../../src/service/vector/summary-vector-index-archive-service', () =
   // buildLiveSummaryVectorRows_ACU 取 prepared.rows 恒为 undefined → live 表恒空 →
   // 只要 summaryTable 非 null 就恒判 stale，对账分支从未被真实测试。
   buildPreparedRows_ACU: () => ({ rows: h.preparedRows, skippedRowCount: 0, error: '' }),
+  resolveColumnIndexByAliases_ACU: (headerRow: any[], aliases: string[], fallbackIndex = -1) => {
+    const normalized = (Array.isArray(aliases) ? aliases : []).map((a) => String(a ?? '').trim().replace(/\s+/g, ''));
+    const idx = (Array.isArray(headerRow) ? headerRow : []).findIndex((cell) => normalized.includes(String(cell ?? '').trim().replace(/\s+/g, '')));
+    return idx >= 0 ? idx : fallbackIndex;
+  },
+  SUMMARY_TIME_SPAN_COLUMN_ALIASES_ACU: ['时间跨度', '时间', '阶段', '时段'],
+  SUMMARY_LOCATION_COLUMN_ALIASES_ACU: ['地点', '位置', '场景', '场所'],
+  SUMMARY_SUMMARY_COLUMN_ALIASES_ACU: ['概要', '概览', '概述', '摘要'],
+  SUMMARY_INDEX_CODE_COLUMN_ALIASES_ACU: ['编码索引'],
+  SUMMARY_CHRONICLE_COLUMN_ALIASES_ACU: ['纪要', '纪要内容', '纪要正文', '事件纪要', '详细纪要', '正文'],
 }));
 vi.mock('../../../src/service/vector/summary-vector-index-storage-service', () => ({
   loadSummaryVectorIndexChunksFromManifest_ACU: (...a: any[]) => h.loadChunks(...a),
@@ -120,6 +130,7 @@ import {
   processSummaryVectorIndexBeforeGeneration_ACU,
   resetSummaryVectorIndexRuntimeDedupeState_ACU,
 } from '../../../src/service/vector/summary-vector-index-runtime';
+import { logError_ACU, logWarn_ACU } from '../../../src/shared/utils';
 
 
 function row_ACU(key: string, order: number, summary: string): any {
@@ -581,6 +592,176 @@ describe('processSummaryVectorIndexBeforeGeneration_ACU hybrid retrieval', () =>
     expect(content).toContain('recent fixed summary');
   });
 
+});
+
+describe('processSummaryVectorIndexBeforeGeneration_ACU crossfire overwrite columns', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetSummaryVectorIndexRuntimeDedupeState_ACU();
+    h.chat = [{ is_user: true, mes: 'latest user' } as any];
+    h.entries = [];
+    h.callAI.mockResolvedValue('<keywords>secret relic</keywords>');
+    h.createEmbeddings.mockResolvedValue([{ index: 0, embedding: [1, 0] }]);
+    h.createEntries.mockResolvedValue(undefined);
+    h.setEntries.mockResolvedValue(undefined);
+    h.loadChunks.mockImplementation(async () => h.chunks);
+    h.clearMissing.mockResolvedValue(true);
+    h.clearInvalid.mockResolvedValue({ chatStateCleared: true, cacheCleared: true, flushTaskCountCleared: 1 });
+    h.enqueueFlush.mockResolvedValue({ queued: true, scopeKey: 'scope', debounceUntil: Date.now() });
+    h.missingError = false;
+    h.invalidError = false;
+    h.snapshot = null;
+    h.registry = [];
+    h.readSnapshot.mockReset();
+    h.validateSnapshot.mockReset();
+    h.saveChatStrict.mockResolvedValue(undefined);
+    h.tagData = {};
+    h.writeTagData.mockReset();
+    vi.stubGlobal('fetch', vi.fn());
+    // 与实时纪要表逐行对应的索引行（rowId / 编码索引可命中实时行）。
+    h.rows = [
+      { rowKey: 'k1', rowId: '1', rowOrder: 0, timeSpan: 't1', location: 'loc1', summary: '概要一', indexCode: 'AM0001', status: 'active' },
+      { rowKey: 'k2', rowId: '2', rowOrder: 1, timeSpan: 't2', location: 'loc2', summary: '概要二', indexCode: 'AM0002', status: 'active' },
+    ];
+    h.chunks = [
+      { chunkId: 'chunk-k1', rowKey: 'k1', sequence: 0, text: 'unrelated dense vector row', textHash: 'hash-k1', vector: [1, 0] },
+      { chunkId: 'chunk-k2', rowKey: 'k2', sequence: 0, text: 'secret relic ancient tale', textHash: 'hash-k2', vector: [0, 1] },
+    ];
+    h.config = defaultConfig_ACU();
+    h.preparedRows = [{ rowKey: 'k1' }, { rowKey: 'k2' }];
+  });
+
+  function expectNoSilentFallback_ACU(): void {
+    expect(vi.mocked(logWarn_ACU)).not.toHaveBeenCalled();
+    expect(vi.mocked(logError_ACU)).not.toHaveBeenCalled();
+  }
+
+  function summaryTableFixture_ACU(exportOverrides: Record<string, any> = {}): any {
+    return {
+      summaryKey: 'summary-source',
+      table: {
+        name: '纪要表',
+        content: [
+          ['row_id', '时间跨度', '地点', '纪要', '概览', '编码索引'],
+          ['1', 't1', 'loc1', '正文一', '概要一', 'AM0001'],
+          ['2', 't2', 'loc2', '正文二', '概要二', 'AM0002'],
+        ],
+        exportConfig: {
+          extraIndexEnabled: true,
+          extraIndexColumns: ['概览', '编码索引'],
+          extraIndexInjectionTemplate: '<已发生的事件概览>\n$1\n</已发生的事件概览>',
+          ...exportOverrides,
+        },
+      },
+    };
+  }
+
+  it('有附加索引配置时按配置列拼表并套模板，不再写死4列', async () => {
+    h.summaryTable = summaryTableFixture_ACU();
+
+    const result = await processSummaryVectorIndexBeforeGeneration_ACU({ userInput: 'secret relic', source: 'custom-columns' });
+
+    expect(result.success).toBe(true);
+    expectNoSilentFallback_ACU();
+    const content = createdContent_ACU();
+    expect(content).toContain('<已发生的事件概览>');
+    expect(content).toContain('| 概览 | 编码索引 |');
+    expect(content).toContain('概要一');
+    expect(content).toContain('AM0002');
+    expect(content).not.toContain('| 时间 | 地点 | 概要 | 编码索引 |');
+    expect(content).not.toContain('loc1');
+  });
+
+  it('配置列包含时间地点时取实时表对应单元格', async () => {
+    h.summaryTable = summaryTableFixture_ACU({ extraIndexColumns: ['时间跨度', '地点', '概览', '编码索引'] });
+
+    const result = await processSummaryVectorIndexBeforeGeneration_ACU({ userInput: 'secret relic', source: 'custom-columns-full' });
+
+    expect(result.success).toBe(true);
+    expectNoSilentFallback_ACU();
+    const content = createdContent_ACU();
+    expect(content).toContain('| 时间跨度 | 地点 | 概览 | 编码索引 |');
+    expect(content).toContain('t1');
+    expect(content).toContain('loc2');
+  });
+
+  it('附加索引关闭时回退固定4列', async () => {
+    h.summaryTable = summaryTableFixture_ACU({ extraIndexEnabled: false });
+
+    const result = await processSummaryVectorIndexBeforeGeneration_ACU({ userInput: 'secret relic', source: 'custom-columns-disabled' });
+
+    expect(result.success).toBe(true);
+    expectNoSilentFallback_ACU();
+    expect(createdContent_ACU()).toContain('| 时间 | 地点 | 概要 | 编码索引 |');
+  });
+
+  it('无实时纪要表时回退固定4列', async () => {
+    h.summaryTable = null;
+    h.preparedRows = [];
+
+    const result = await processSummaryVectorIndexBeforeGeneration_ACU({ userInput: 'secret relic', source: 'custom-columns-no-table' });
+
+    expect(result.success).toBe(true);
+    expectNoSilentFallback_ACU();
+    const content = createdContent_ACU();
+    expect(content).toContain('| 时间 | 地点 | 概要 | 编码索引 |');
+    expect(content).toContain('AM0001');
+  });
+
+  it('模板不含 $1 时用纪要索引标题包裹自定义列', async () => {
+    h.summaryTable = summaryTableFixture_ACU({ extraIndexInjectionTemplate: '' });
+
+    const result = await processSummaryVectorIndexBeforeGeneration_ACU({ userInput: 'secret relic', source: 'custom-columns-no-template' });
+
+    expect(result.success).toBe(true);
+    expectNoSilentFallback_ACU();
+    const content = createdContent_ACU();
+    expect(content).toContain('# 纪要索引');
+    expect(content).toContain('| 概览 | 编码索引 |');
+    expect(content).not.toContain('<已发生的事件概览>');
+  });
+
+  it('配置列全是未知列时回退固定4列', async () => {
+    h.summaryTable = summaryTableFixture_ACU({ extraIndexColumns: ['不存在的列'] });
+
+    const result = await processSummaryVectorIndexBeforeGeneration_ACU({ userInput: 'secret relic', source: 'custom-columns-unknown' });
+
+    expect(result.success).toBe(true);
+    expectNoSilentFallback_ACU();
+    const content = createdContent_ACU();
+    expect(content).toContain('| 时间 | 地点 | 概要 | 编码索引 |');
+    expect(content).toContain('AM0001');
+  });
+
+  it('实时表缺编码列时用索引行自带字段兜底', async () => {
+    // 实时表没有编码列 → 按编码定位全部 miss，单元格必须来自索引行（概要一），而非实时表（实时概要一）。
+    h.summaryTable = {
+      summaryKey: 'summary-source',
+      table: {
+        name: '纪要表',
+        content: [
+          ['row_id', '时间跨度', '地点', '纪要', '概览'],
+          ['1', 't1', 'loc1', '正文一', '实时概要一'],
+          ['2', 't2', 'loc2', '正文二', '实时概要二'],
+        ],
+        exportConfig: {
+          extraIndexEnabled: true,
+          extraIndexColumns: ['概览'],
+          extraIndexInjectionTemplate: '<已发生的事件概览>\n$1\n</已发生的事件概览>',
+        },
+      },
+    };
+
+    const result = await processSummaryVectorIndexBeforeGeneration_ACU({ userInput: 'secret relic', source: 'custom-columns-no-index-col' });
+
+    expect(result.success).toBe(true);
+    expectNoSilentFallback_ACU();
+    const content = createdContent_ACU();
+    expect(content).toContain('| 概览 |');
+    expect(content).not.toContain('| 时间 | 地点 | 概要 | 编码索引 |');
+    expect(content).toContain('概要一');
+    expect(content).not.toContain('实时概要一');
+  });
 });
 
 describe('processSummaryVectorIndexBeforeGeneration_ACU missing snapshot recovery', () => {


### PR DESCRIPTION
## 背景

同一条世界书条目 `TavernDB-ACU-CustomExport-纪要索引`，交火前后内容口径不一致：

- 交火未达标时：按纪要表导出配置生成，比如只配了 `概览 + 编码索引` 就是 2 列；
- 交火达标、发送前召回覆盖后：被写死为 `时间 | 地点 | 概要 | 编码索引` 4 列，
  配置被无视，且此后普通填表也不会再把它改回去（内容被保护）。

## 改动

- 交火覆盖改按纪要表导出配置的附加索引列拼表，并套用配置的包裹模板；
  无配置 / 配置列非法时回退原来的固定 4 列，行为不变。
- 行定位只按编码索引（与召回侧单键匹配习惯一致）。
- 纪要表列别名抽成共用常量，建索引与交火兜底同一套口径。
- 新增 7 个用例（tests/service/vector/summary-vector-index-runtime.test.ts）。

## 验证

- `vitest run tests/service/vector` 相关两个文件：66/66 通过
- `tsc --noEmit`：零错误
- 未在 SillyTavern 内加载构建产物实测，请维护者帮忙验证实际效果

## 说明

本人不懂 JS，改动由 AI 辅助编写并经自查，如有不妥请直接指出。