### PR TITLE
feat(data-mgmt): 新增全局旧隔离标签清理

### DIFF
--- a/src/data/repositories/profile-repo.ts
+++ b/src/data/repositories/profile-repo.ts
@@ -88,6 +88,24 @@ export function writeProfileTemplateToStorage_ACU(code: string, templateStr: str
     store.setItem(getProfileTemplateKey_ACU(code), String(templateStr || ''));
 }
 
+/**
+ * 删除非默认隔离标签对应的设置与表格模板。
+ *
+ * 空标识代表默认 Profile，必须保留；调用方只应传入待退役的旧隔离码。
+ */
+export function deleteProfileFromStorage_ACU(code: string): void {
+    const normalizedCode = normalizeIsolationCode_ACU(code);
+    if (!normalizedCode) {
+        throw new Error('不能删除默认 Profile。');
+    }
+    const store = getConfigStorage_ACU();
+    if (!store || typeof store.removeItem !== 'function') {
+        throw new Error('当前配置存储不支持删除 Profile。');
+    }
+    store.removeItem(getProfileSettingsKey_ACU(normalizedCode));
+    store.removeItem(getProfileTemplateKey_ACU(normalizedCode));
+}
+
 export function saveCurrentProfileTemplate_ACU(templateStr?: string, settings?: any): void {
     const tpl = templateStr !== undefined ? templateStr : TABLE_TEMPLATE_ACU;
     const code = normalizeIsolationCode_ACU(settings?.dataIsolationCode || '');

--- a/src/presentation-v2/composables/useDataManagement.ts
+++ b/src/presentation-v2/composables/useDataManagement.ts
@@ -18,6 +18,7 @@ import {
   saveSettings_ACU,
   switchIsolationProfile_ACU,
 } from '../../service/settings/settings-service';
+import { cleanupLegacyIsolationProfiles_ACU } from '../../service/settings/legacy-isolation-cleanup-service';
 import { normalizeResetDefaultsOptions, hasSelectedResetDefaultsOption, resetAllDefaults_ACU, type ResetDefaultsCleanupOptions } from '../../service/table/reset-defaults-service';
 import { getCurrentStorageMode, isSqliteMode } from '../../service/table/storage-mode';
 import { reloadStorageProvider } from '../../service/table/table-storage-strategy';
@@ -148,6 +149,12 @@ export function useDataManagement() {
   const isolationHistoryOptions = computed(() =>
     isolationHistory.value.map(code => ({ value: code, label: code })),
   );
+  const legacyIsolationCodes = computed(() => {
+    const codes = new Set(isolationHistory.value);
+    if (activeIsolationCode.value) codes.add(activeIsolationCode.value);
+    return [...codes];
+  });
+  const legacyIsolationCount = computed(() => legacyIsolationCodes.value.length);
   const rangeLabel = computed(() => {
     const start = normalizeFloorValue(deleteRange.startFloor);
     const end = normalizeFloorValue(deleteRange.endFloor);
@@ -264,6 +271,29 @@ export function useDataManagement() {
       logError_ACU('[ACU-V2] removeHistory failed', e);
       message.value = null;
       toast.error('移除历史标识失败，详情见运行日志。');
+    } finally {
+      busyAction.value = '';
+    }
+  }
+
+  async function cleanupLegacyIsolationProfiles(): Promise<void> {
+    if (busyAction.value) return;
+    busyAction.value = 'cleanup-legacy-isolation';
+    try {
+      const result = await cleanupLegacyIsolationProfiles_ACU();
+      refresh();
+      message.value = null;
+      if (result.failedCodes.length > 0) {
+        toast.warning(`已清理 ${result.removedCodes.length} 个旧隔离标签；${result.failedCodes.length} 个删除失败，已保留登记，可重试。`);
+      } else if (result.removedCodes.length === 0) {
+        toast.info('没有发现可清理的旧隔离标签。');
+      } else {
+        toast.success(`已清理 ${result.removedCodes.length} 个旧隔离标签，并切换到默认数据。`);
+      }
+    } catch (e: any) {
+      logError_ACU('[ACU-V2] cleanupLegacyIsolationProfiles failed', e);
+      message.value = null;
+      toast.error('清理旧隔离标签失败，详情见运行日志。');
     } finally {
       busyAction.value = '';
     }
@@ -766,6 +796,8 @@ export function useDataManagement() {
     v2RecoverySummary,
     v2IsolationDiagnostics,
     isolationHistoryOptions,
+    legacyIsolationCodes,
+    legacyIsolationCount,
     currentIsolationLabel,
     isolationModeLabel,
     deleteRange,
@@ -783,6 +815,7 @@ export function useDataManagement() {
     getCheckpointTargetStorageMode,
     applyIsolation,
     removeHistory,
+    cleanupLegacyIsolationProfiles,
     deleteCurrentIsolationEntries,
     importCombinedSettings,
     exportCombinedSettings,

--- a/src/presentation-v2/pages/DataMgmtPage.vue
+++ b/src/presentation-v2/pages/DataMgmtPage.vue
@@ -438,7 +438,19 @@
             >
               恢复默认配置
             </AcuButton>
+            <AcuButton
+              block
+              variant="danger"
+              :disabled="runtimeDiagnostic.busy.value || !!flow.busyAction.value"
+              :loading="flow.busyAction.value === 'cleanup-legacy-isolation'"
+              @click="onCleanupLegacyIsolationProfiles"
+            >
+              全局旧隔离标签清理
+            </AcuButton>
           </div>
+          <p class="acu-v2-data-mgmt-page__meta">
+            清理全部退役隔离标签及其全局设置/表格模板，并切回默认数据；不会删除聊天正文或各聊天已保存的历史表格数据。当前发现 {{ flow.legacyIsolationCount.value }} 个旧隔离标签。
+          </p>
         </AcuPanel>
       </div>
     </AcuPanelGrid>
@@ -659,6 +671,27 @@ async function onDeleteLocalData(mode: "current" | "all"): Promise<void> {
   }))) return;
   if (runtimeDiagnostic.busy.value) return;
   void flow.deleteLocalData("all");
+}
+
+async function onCleanupLegacyIsolationProfiles(): Promise<void> {
+  if (runtimeDiagnostic.busy.value) return;
+  const codes = flow.legacyIsolationCodes.value;
+  const codeText = codes.length > 0 ? `：${codes.join("、")}` : "";
+  const confirmed = await dialogStore.confirm({
+    title: "全局旧隔离标签清理",
+    message:
+      `将清理全部 ${codes.length} 个旧隔离标签${codeText}。\n` +
+      "· 如有当前激活标识，会切回默认数据；\n" +
+      "· 删除这些标签对应的全局设置与表格模板；\n" +
+      "· 不会删除聊天正文，也不会改写各聊天里已保存的历史表格数据；\n" +
+      "· 若单个标签删除失败，会保留登记供重试。\n" +
+      "此操作不可恢复。确认继续？",
+    confirmLabel: "清理旧隔离标签",
+    confirmVariant: "danger",
+  });
+  if (!confirmed) return;
+  if (runtimeDiagnostic.busy.value) return;
+  await flow.cleanupLegacyIsolationProfiles();
 }
 
 

--- a/src/service/settings/legacy-isolation-cleanup-service.ts
+++ b/src/service/settings/legacy-isolation-cleanup-service.ts
@@ -1,0 +1,82 @@
+/**
+ * 退役隔离标签的全局 Profile 清理编排。
+ *
+ * 只清理全局隔离登记及对应 Profile（设置/表格模板），不删除聊天正文，也不改写
+ * 各聊天消息中已经持久化的历史表格数据。
+ */
+import { normalizeIsolationCode_ACU } from '../../shared/data-constants';
+import { logWarn_ACU } from '../../shared/utils';
+import { deleteProfileFromStorage_ACU, globalMeta_ACU, saveGlobalMeta_ACU } from '../../data/repositories/profile-repo';
+import { getDataIsolationHistory_ACU } from '../../data/repositories/isolation-repo';
+import { settings_ACU } from '../runtime/state-manager';
+import { saveSettings_ACU, switchIsolationProfile_ACU } from './settings-service';
+
+export interface LegacyIsolationCleanupFailure_ACU {
+  code: string;
+  error: string;
+}
+
+export interface LegacyIsolationCleanupResult_ACU {
+  removedCodes: string[];
+  failedCodes: LegacyIsolationCleanupFailure_ACU[];
+  switchedToDefault: boolean;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error || '未知错误');
+}
+
+/**
+ * 清理全部旧隔离标签。
+ *
+ * 先切回默认槽，再逐个删除 Profile。单个删除失败时保留该标签的历史登记，
+ * 便于用户重试；成功项则从登记中移除。
+ */
+export async function cleanupLegacyIsolationProfiles_ACU(): Promise<LegacyIsolationCleanupResult_ACU> {
+  const activeCode = normalizeIsolationCode_ACU(
+    settings_ACU?.dataIsolationCode || globalMeta_ACU?.activeIsolationCode || '',
+  );
+  const switchedToDefault = !!activeCode;
+  if (switchedToDefault) {
+    await switchIsolationProfile_ACU('');
+  }
+
+  const codes = [...new Set(
+    [activeCode, ...getDataIsolationHistory_ACU()]
+      .map(code => normalizeIsolationCode_ACU(code))
+      .filter(Boolean),
+  )];
+
+  if (codes.length === 0) {
+    return { removedCodes: [], failedCodes: [], switchedToDefault };
+  }
+
+  const removedCodes: string[] = [];
+  const failedCodes: LegacyIsolationCleanupFailure_ACU[] = [];
+  for (const code of codes) {
+    try {
+      deleteProfileFromStorage_ACU(code);
+      removedCodes.push(code);
+    } catch (error) {
+      const message = errorMessage(error);
+      failedCodes.push({ code, error: message });
+      logWarn_ACU(`[旧隔离清理] 删除 Profile 失败: ${code}`, error);
+    }
+  }
+
+  globalMeta_ACU.activeIsolationCode = '';
+  globalMeta_ACU.isolationCodeList = failedCodes.map(item => item.code);
+  settings_ACU.dataIsolationCode = '';
+  settings_ACU.dataIsolationEnabled = false;
+  settings_ACU.dataIsolationHistory = [];
+
+  if (!saveGlobalMeta_ACU()) {
+    throw new Error('旧隔离标签登记保存失败，请检查存储状态后重试。');
+  }
+  const saveResult = saveSettings_ACU();
+  if (!saveResult.saved) {
+    throw new Error(saveResult.warning || saveResult.error || '默认设置保存失败。');
+  }
+
+  return { removedCodes, failedCodes, switchedToDefault };
+}

--- a/tests/data/repositories/profile-repo.test.ts
+++ b/tests/data/repositories/profile-repo.test.ts
@@ -13,6 +13,7 @@ const {
     mockStore: {
       getItem: vi.fn((key: string) => store.get(key) ?? null),
       setItem: vi.fn((key: string, value: string) => { store.set(key, value); }),
+      removeItem: vi.fn((key: string) => { store.delete(key); }),
       _clear: () => store.clear(),
       _store: store,
     },
@@ -53,6 +54,7 @@ import {
   writeProfileSettingsToStorage_ACU,
   readProfileTemplateFromStorage_ACU,
   writeProfileTemplateToStorage_ACU,
+  deleteProfileFromStorage_ACU,
   saveCurrentProfileTemplate_ACU,
   sanitizeSettingsForProfileSave_ACU,
 } from '../../../src/data/repositories/profile-repo';
@@ -180,6 +182,30 @@ describe('writeProfileTemplateToStorage_ACU', () => {
   it('写入模板到存储', () => {
     writeProfileTemplateToStorage_ACU('code_1', '{"sheet_0":{}}');
     expect(mockStore.setItem).toHaveBeenCalledWith('acu_template_code_1', '{"sheet_0":{}}');
+  });
+});
+
+// ═══ deleteProfileFromStorage_ACU ═══
+describe('deleteProfileFromStorage_ACU', () => {
+  it('删除指定标签的设置与模板，不影响默认 Profile', () => {
+    mockStore._store.set('acu_settings_old', 'settings');
+    mockStore._store.set('acu_template_old', 'template');
+    mockStore._store.set('acu_settings_', 'default-settings');
+    mockStore._store.set('acu_template_', 'default-template');
+
+    deleteProfileFromStorage_ACU('old');
+
+    expect(mockStore.removeItem).toHaveBeenCalledWith('acu_settings_old');
+    expect(mockStore.removeItem).toHaveBeenCalledWith('acu_template_old');
+    expect(mockStore._store.has('acu_settings_old')).toBe(false);
+    expect(mockStore._store.has('acu_template_old')).toBe(false);
+    expect(mockStore._store.get('acu_settings_')).toBe('default-settings');
+    expect(mockStore._store.get('acu_template_')).toBe('default-template');
+  });
+
+  it('空标签拒绝删除，避免误删默认 Profile', () => {
+    expect(() => deleteProfileFromStorage_ACU('   ')).toThrow('不能删除默认 Profile');
+    expect(mockStore.removeItem).not.toHaveBeenCalled();
   });
 });
 

--- a/tests/presentation-v2/data-mgmt/data-mgmt-page.test.ts
+++ b/tests/presentation-v2/data-mgmt/data-mgmt-page.test.ts
@@ -85,6 +85,13 @@ async function mountDataMgmtPage(chatFileIdentifier = 'chat-data', initialMixedD
     const index = isolationHistory.indexOf(code);
     if (index >= 0) isolationHistory.splice(index, 1);
   });
+  const cleanupLegacyIsolation = vi.fn(async () => {
+    const removedCodes = [...isolationHistory];
+    isolationHistory.splice(0, isolationHistory.length);
+    settings.dataIsolationCode = '';
+    settings.dataIsolationEnabled = false;
+    return { removedCodes, failedCodes: [], switchedToDefault: true };
+  });
   const deleteGenerated = vi.fn(async () => undefined);
   const deleteLocalDataWithScope = vi.fn(async (_mode: string, _start: number | null, _end: number | null, expectedPath?: 'purge' | 'range') => {
     if (expectedPath === 'purge') {
@@ -217,6 +224,9 @@ async function mountDataMgmtPage(chatFileIdentifier = 'chat-data', initialMixedD
     switchIsolationProfile_ACU: switchIsolation,
     applyCombinedSettingsImport_ACU: vi.fn(() => ['charCardPrompt']),
   }));
+  vi.doMock('../../../src/service/settings/legacy-isolation-cleanup-service', () => ({
+    cleanupLegacyIsolationProfiles_ACU: cleanupLegacyIsolation,
+  }));
   vi.doMock('../../../src/service/chat/chat-service', async () => {
     const actual = await vi.importActual<any>('../../../src/service/chat/chat-service');
     return {
@@ -284,6 +294,7 @@ async function mountDataMgmtPage(chatFileIdentifier = 'chat-data', initialMixedD
     saveSettings,
     switchIsolation,
     removeHistory,
+    cleanupLegacyIsolation,
     deleteGenerated,
     deleteLocalDataWithScope,
     cleanupWorldbook,
@@ -361,6 +372,7 @@ describe('DataMgmtPage', () => {
     expect(text).not.toContain('交火模式索引管理');
     expect(text).not.toContain('删除当前交火索引');
     expect(text).not.toContain('清空临时缓存');
+    expect(text).toContain('全局旧隔离标签清理');
 
     mount.__resetAcuV2MountForTests();
   });
@@ -413,6 +425,41 @@ describe('DataMgmtPage', () => {
     expect(cleanupPanel.textContent || '').toContain('保留数据层数');
     expect(cleanupPanel.textContent || '').not.toContain('删除当前标识本地数据');
     expect(cleanupPanel.textContent || '').toContain('恢复默认配置');
+    expect(cleanupPanel.textContent || '').toContain('全局旧隔离标签清理');
+
+    mount.__resetAcuV2MountForTests();
+  });
+
+  it('全局旧隔离标签清理确认前取消不会执行删除', async () => {
+    const { mount, cleanupLegacyIsolation } = await mountDataMgmtPage();
+
+    const button = Array.from(document.querySelectorAll<HTMLButtonElement>('button'))
+      .find(item => item.textContent?.includes('全局旧隔离标签清理'));
+    expect(button).not.toBeUndefined();
+    button!.click();
+    await new Promise(r => setTimeout(r, 0));
+    expect(document.querySelector('.acu-dialog-layer')?.textContent).toContain('alpha、beta');
+    expect(document.querySelector('.acu-dialog-layer')?.textContent).toContain('不会删除聊天正文');
+
+    await clickDialogButton('取消');
+    expect(cleanupLegacyIsolation).not.toHaveBeenCalled();
+
+    mount.__resetAcuV2MountForTests();
+  });
+
+  it('全局旧隔离标签清理确认后删除全部 Profile 并切换到默认数据', async () => {
+    const { mount, cleanupLegacyIsolation, settings } = await mountDataMgmtPage();
+
+    const button = Array.from(document.querySelectorAll<HTMLButtonElement>('button'))
+      .find(item => item.textContent?.includes('全局旧隔离标签清理'));
+    button!.click();
+    await clickDialogButton('清理旧隔离标签');
+    await new Promise(r => setTimeout(r, 0));
+
+    expect(cleanupLegacyIsolation).toHaveBeenCalledOnce();
+    expect(settings.dataIsolationCode).toBe('');
+    expect(settings.dataIsolationEnabled).toBe(false);
+    expect(document.querySelector('.acu-v2-toast--success')?.textContent).toContain('已清理 2 个旧隔离标签');
 
     mount.__resetAcuV2MountForTests();
   });
@@ -1086,11 +1133,11 @@ describe('DataMgmtPage', () => {
 
 
 
-  it('全页只保留删除所有本地数据为红色危险按钮', async () => {
+  it('全页危险按钮仅包含删除所有本地数据和全局旧隔离标签清理', async () => {
     const { mount } = await mountDataMgmtPage();
 
     const dangerButtons = Array.from(document.querySelectorAll<HTMLButtonElement>('.acu-v2-data-mgmt-page button.acu-btn--danger'));
-    expect(dangerButtons.map(button => button.textContent?.trim())).toEqual(['删除所有本地数据']);
+    expect(dangerButtons.map(button => button.textContent?.trim())).toEqual(['删除所有本地数据', '全局旧隔离标签清理']);
 
     mount.__resetAcuV2MountForTests();
   });

--- a/tests/presentation-v2/data-mgmt/use-data-management.test.ts
+++ b/tests/presentation-v2/data-mgmt/use-data-management.test.ts
@@ -9,6 +9,13 @@ async function loadFlow() {
   const history = ['alpha', 'beta'];
   const switchIsolation = vi.fn(async (code: string) => { settings.dataIsolationCode = code; });
   const removeHistory = vi.fn((code: string) => history.splice(history.indexOf(code), 1));
+  const cleanupLegacyIsolation = vi.fn(async () => {
+    const removedCodes = [...history];
+    history.splice(0, history.length);
+    settings.dataIsolationCode = '';
+    settings.dataIsolationEnabled = false;
+    return { removedCodes, failedCodes: [], switchedToDefault: true };
+  });
   const deleteGenerated = vi.fn(async () => undefined);
   const applyTemplateScope = vi.fn();
   const overrideLatest = vi.fn(async () => 2);
@@ -23,6 +30,7 @@ async function loadFlow() {
 
   vi.doMock('../../../src/service/runtime/state-manager', () => ({ settings_ACU: settings, currentChatFileIdentifier_ACU: 'chat', currentJsonTableData_ACU: { sheet_a: {} }, getCurrentIsolationKey_ACU: () => settings.dataIsolationCode }));
   vi.doMock('../../../src/service/settings/settings-service', () => ({ applyTemplateScopeForCurrentChat_ACU: applyTemplateScope, applyCombinedSettingsImport_ACU: vi.fn(), getDataIsolationHistory_ACU: () => [...history], removeDataIsolationHistory_ACU: removeHistory, saveSettings_ACU: vi.fn(), switchIsolationProfile_ACU: switchIsolation }));
+  vi.doMock('../../../src/service/settings/legacy-isolation-cleanup-service', () => ({ cleanupLegacyIsolationProfiles_ACU: cleanupLegacyIsolation }));
   vi.doMock('../../../src/service/settings/settings-write-service', () => ({
     resetAllPromptsToDefault_ACU: vi.fn(() => ({ ok: true, code: 'ok', changed: true })),
     snapshotSettingsFields_ACU: vi.fn(() => ({})),
@@ -47,7 +55,7 @@ async function loadFlow() {
   const toastSuccess = vi.spyOn(toast, 'success').mockImplementation(() => {});
   const toastError = vi.spyOn(toast, 'error').mockImplementation(() => {});
   const toastWarning = vi.spyOn(toast, 'warning').mockImplementation(() => {});
-  return { flow: useDataManagement(), settings, history, switchIsolation, removeHistory, deleteGenerated, applyTemplateScope, overrideLatest, deleteScoped, reloadProvider, loadOrCreate, refreshMerged, cleanupWorldbook, scan, prepare, commit, toast, toastSuccess, toastError, toastWarning };
+  return { flow: useDataManagement(), settings, history, switchIsolation, removeHistory, cleanupLegacyIsolation, deleteGenerated, applyTemplateScope, overrideLatest, deleteScoped, reloadProvider, loadOrCreate, refreshMerged, cleanupWorldbook, scan, prepare, commit, toast, toastSuccess, toastError, toastWarning };
 }
 
 beforeEach(() => { vi.restoreAllMocks(); vi.unstubAllGlobals(); });
@@ -79,6 +87,36 @@ describe('useDataManagement', () => {
     expect(d.loadOrCreate).toHaveBeenCalled();
     expect(d.refreshMerged).toHaveBeenCalled();
     expect(d.cleanupWorldbook).toHaveBeenCalled();
+  });
+
+  it('全局旧隔离标签清理成功后刷新历史并切换到默认状态', async () => {
+    const d = await loadFlow();
+    d.flow.refresh();
+    expect(d.flow.legacyIsolationCount.value).toBe(2);
+
+    await d.flow.cleanupLegacyIsolationProfiles();
+
+    expect(d.cleanupLegacyIsolation).toHaveBeenCalledOnce();
+    expect(d.flow.legacyIsolationCount.value).toBe(0);
+    expect(d.flow.currentIsolationLabel.value).toBe('默认数据（未隔离）');
+    expect(d.toastSuccess).toHaveBeenCalledWith('已清理 2 个旧隔离标签，并切换到默认数据。');
+  });
+
+  it('部分旧隔离标签清理失败时保留计数并展示警告', async () => {
+    const d = await loadFlow();
+    d.flow.refresh();
+    d.cleanupLegacyIsolation.mockResolvedValueOnce({
+      removedCodes: ['alpha'],
+      failedCodes: [{ code: 'beta', error: 'remove failed' }],
+      switchedToDefault: true,
+    });
+    d.settings.dataIsolationCode = '';
+    d.history.splice(0, d.history.length, 'beta');
+
+    await d.flow.cleanupLegacyIsolationProfiles();
+
+    expect(d.flow.legacyIsolationCount.value).toBe(1);
+    expect(d.toastWarning).toHaveBeenCalledWith('已清理 1 个旧隔离标签；1 个删除失败，已保留登记，可重试。');
   });
   it('V2 诊断与恢复只透传服务端冻结的 planId 和确认值', async () => {
     const d = await loadFlow();

--- a/tests/service/settings/legacy-isolation-cleanup-service.test.ts
+++ b/tests/service/settings/legacy-isolation-cleanup-service.test.ts
@@ -1,0 +1,120 @@
+/**
+ * 全局旧隔离标签清理服务单元测试。
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  settings: {
+    dataIsolationCode: 'old-a',
+    dataIsolationEnabled: true,
+    dataIsolationHistory: ['legacy-setting-history'],
+  } as any,
+  globalMeta: {
+    activeIsolationCode: 'old-a',
+    isolationCodeList: ['old-a', 'old-b'],
+  } as any,
+  switchIsolationProfile: vi.fn(async (code: string) => {
+    mocks.settings.dataIsolationCode = code;
+    mocks.settings.dataIsolationEnabled = !!code;
+    if (!code) mocks.globalMeta.activeIsolationCode = '';
+  }),
+  saveSettings: vi.fn(() => ({ saved: true, storageType: 'memory' as const })),
+  deleteProfile: vi.fn(),
+  saveGlobalMeta: vi.fn(() => true),
+}));
+
+vi.mock('../../../src/shared/data-constants', () => ({
+  normalizeIsolationCode_ACU: (code: unknown) => String(code || '').trim(),
+}));
+
+vi.mock('../../../src/shared/utils', () => ({
+  logWarn_ACU: vi.fn(),
+}));
+
+vi.mock('../../../src/service/runtime/state-manager', () => ({
+  settings_ACU: mocks.settings,
+}));
+
+vi.mock('../../../src/service/settings/settings-service', () => ({
+  switchIsolationProfile_ACU: mocks.switchIsolationProfile,
+  saveSettings_ACU: mocks.saveSettings,
+}));
+
+vi.mock('../../../src/data/repositories/isolation-repo', () => ({
+  getDataIsolationHistory_ACU: () => [...mocks.globalMeta.isolationCodeList],
+}));
+
+vi.mock('../../../src/data/repositories/profile-repo', () => ({
+  globalMeta_ACU: mocks.globalMeta,
+  saveGlobalMeta_ACU: mocks.saveGlobalMeta,
+  deleteProfileFromStorage_ACU: mocks.deleteProfile,
+}));
+
+import { cleanupLegacyIsolationProfiles_ACU } from '../../../src/service/settings/legacy-isolation-cleanup-service';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.settings.dataIsolationCode = 'old-a';
+  mocks.settings.dataIsolationEnabled = true;
+  mocks.settings.dataIsolationHistory = ['legacy-setting-history'];
+  mocks.globalMeta.activeIsolationCode = 'old-a';
+  mocks.globalMeta.isolationCodeList = ['old-a', 'old-b'];
+  mocks.saveGlobalMeta.mockReturnValue(true);
+  mocks.saveSettings.mockReturnValue({ saved: true, storageType: 'memory' });
+});
+
+describe('cleanupLegacyIsolationProfiles_ACU', () => {
+  it('切回默认槽并删除全部历史隔离标签的 Profile', async () => {
+    const result = await cleanupLegacyIsolationProfiles_ACU();
+
+    expect(mocks.switchIsolationProfile).toHaveBeenCalledOnce();
+    expect(mocks.switchIsolationProfile).toHaveBeenCalledWith('');
+    expect(mocks.deleteProfile).toHaveBeenCalledTimes(2);
+    expect(mocks.deleteProfile).toHaveBeenNthCalledWith(1, 'old-a');
+    expect(mocks.deleteProfile).toHaveBeenNthCalledWith(2, 'old-b');
+    expect(mocks.globalMeta.activeIsolationCode).toBe('');
+    expect(mocks.globalMeta.isolationCodeList).toEqual([]);
+    expect(mocks.settings.dataIsolationCode).toBe('');
+    expect(mocks.settings.dataIsolationEnabled).toBe(false);
+    expect(mocks.settings.dataIsolationHistory).toEqual([]);
+    expect(mocks.saveGlobalMeta).toHaveBeenCalledOnce();
+    expect(mocks.saveSettings).toHaveBeenCalledOnce();
+    expect(result).toEqual({
+      removedCodes: ['old-a', 'old-b'],
+      failedCodes: [],
+      switchedToDefault: true,
+    });
+  });
+
+  it('激活标签即使未进入历史列表也会被清理', async () => {
+    mocks.globalMeta.isolationCodeList = ['old-b'];
+
+    const result = await cleanupLegacyIsolationProfiles_ACU();
+
+    expect(mocks.deleteProfile).toHaveBeenCalledWith('old-a');
+    expect(mocks.deleteProfile).toHaveBeenCalledWith('old-b');
+    expect(result.removedCodes).toEqual(['old-a', 'old-b']);
+  });
+
+  it('单个 Profile 删除失败时保留失败标签供重试，不中断其他清理', async () => {
+    mocks.deleteProfile.mockImplementation((code: string) => {
+      if (code === 'old-b') throw new Error('remove failed');
+    });
+
+    const result = await cleanupLegacyIsolationProfiles_ACU();
+
+    expect(result.removedCodes).toEqual(['old-a']);
+    expect(result.failedCodes).toEqual([{ code: 'old-b', error: 'remove failed' }]);
+    expect(mocks.globalMeta.activeIsolationCode).toBe('');
+    expect(mocks.globalMeta.isolationCodeList).toEqual(['old-b']);
+    expect(mocks.saveGlobalMeta).toHaveBeenCalledOnce();
+  });
+
+  it('切回默认槽失败时中止清理，不删除任何 Profile', async () => {
+    mocks.switchIsolationProfile.mockRejectedValueOnce(new Error('switch failed'));
+
+    await expect(cleanupLegacyIsolationProfiles_ACU()).rejects.toThrow('switch failed');
+    expect(mocks.deleteProfile).not.toHaveBeenCalled();
+    expect(mocks.saveGlobalMeta).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## 背景

旧版“数据隔离标签”已退役，但新版 UI 隐藏了历史标签管理入口，用户无法清理存量隔离 Profile。本次在“数据管理 → 删除与清理”新增“全局旧隔离标签清理”。

## 变更

- 新增全局旧隔离标签清理按钮、数量提示与危险操作确认。
- 清理前先切回默认数据槽，再删除全部旧标签对应的全局设置与表格模板。
- 同步清空隔离历史登记；单个 Profile 删除失败时保留该标签登记供重试。
- 明确不删除聊天正文，也不批量改写各聊天中已持久化的历史表格数据。
- 补充服务层、Profile 存储层、composable 与 DataMgmtPage 的测试。
- PR 仅包含源码与测试，不包含 userscript / 插件构建产物。

## 验证

- `pnpm typecheck`：通过
- `pnpm test`：375 个测试文件，7953 passed / 42 skipped / 0 failed